### PR TITLE
chore(ts-sdk): add index.ts file with the necessary exports to ensure…

### DIFF
--- a/packages/messaging/src/index.ts
+++ b/packages/messaging/src/index.ts
@@ -1,0 +1,34 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+// Main client class
+export { SuiStackMessagingClient } from './client.js';
+
+// Types
+export type * from './types.js';
+
+// Constants
+export {
+	MAINNET_MESSAGING_PACKAGE_CONFIG,
+	TESTNET_MESSAGING_PACKAGE_CONFIG,
+	DEFAULT_SEAL_APPROVE_CONTRACT,
+} from './constants.js';
+
+// Errors
+export * from './error.js';
+
+// Encryption types
+export type {
+	AttachmentMetadata,
+	EncryptedSymmetricKey,
+	SealApproveContract,
+	SealConfig,
+	SessionKeyConfig,
+} from './encryption/types.js';
+
+// Storage types
+export type { StorageAdapter, StorageConfig } from './storage/adapters/storage.js';
+
+// Walrus types
+export { WalrusStorageAdapter } from './storage/adapters/walrus/walrus.js';
+export type * from './storage/adapters/walrus/types.js';


### PR DESCRIPTION
Add an index.ts file with the appropriate exports, so that they can be picked up by the build script and generate the necessary type declaration files.
I tested the validity of this like so:

```
cd packages/messaging
pnpm build
pnpm pack
```

This produces a mysten-messaging-0.0.1.tgz
Then I copy paste this tarball in a fresh typescript project, and then do:

`pnpm add $(pwd)/mysten-messaging-0.0.1.tgz`

Then, in a script.ts, I add the following to ensure the types are recognized:

`import { SuiStackMessagingClient } from "@mysten/messaging";`