### PR TITLE
fix(ts-sdk): an issue with the default package configs

### DIFF
--- a/packages/messaging/src/client.ts
+++ b/packages/messaging/src/client.ts
@@ -104,10 +104,11 @@ export class SuiStackMessagingClient {
 			this.#packageConfig = options.packageConfig;
 		}
 
-		// Resolve sealApproveContract with defaults (use detected network)
-		const detectedNetwork = this.#suiClient.network === 'mainnet' ? 'mainnet' : 'testnet';
-		const sealApproveContract =
-			this.#packageConfig.sealApproveContract ?? DEFAULT_SEAL_APPROVE_CONTRACT[detectedNetwork];
+		// Resolve sealApproveContract with defaults (use same packageId as messaging package)
+		const sealApproveContract = this.#packageConfig.sealApproveContract ?? {
+			packageId: this.#packageConfig.packageId,
+			...DEFAULT_SEAL_APPROVE_CONTRACT,
+		};
 
 		// Initialize EnvelopeEncryption directly
 		this.#envelopeEncryption = new EnvelopeEncryption({

--- a/packages/messaging/src/constants.ts
+++ b/packages/messaging/src/constants.ts
@@ -13,9 +13,9 @@ export const DEFAULT_SEAL_APPROVE_CONTRACT = {
 };
 
 export const TESTNET_MESSAGING_PACKAGE_CONFIG = {
-	packageId: process.env.TESTNET_PACKAGE_ID || FALLBACK_PACKAGE_ID,
+	packageId: FALLBACK_PACKAGE_ID,
 } satisfies MessagingPackageConfig;
 
 export const MAINNET_MESSAGING_PACKAGE_CONFIG = {
-	packageId: process.env.MAINNET_PACKAGE_ID || FALLBACK_PACKAGE_ID,
+	packageId: FALLBACK_PACKAGE_ID,
 } satisfies MessagingPackageConfig;

--- a/packages/messaging/src/constants.ts
+++ b/packages/messaging/src/constants.ts
@@ -1,26 +1,21 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
-import type { SealApproveContract } from './encryption/types.js';
 import type { MessagingPackageConfig } from './types.js';
 
+// Default fallback package ID for when environment variables are not available
+const FALLBACK_PACKAGE_ID = '0x984960ebddd75c15c6d38355ac462621db0ffc7d6647214c802cd3b685e1af3d';
+
 // Default Seal approve contract configurations - uses same package ID as messaging
-export const DEFAULT_SEAL_APPROVE_CONTRACT: Record<'testnet' | 'mainnet', SealApproveContract> = {
-	testnet: {
-		packageId: process.env.TESTNET_PACKAGE_ID || '0xTBD',
-		module: 'seal_policies',
-		functionName: 'seal_approve',
-	},
-	mainnet: {
-		packageId: process.env.MAINNET_PACKAGE_ID || '0xTBD',
-		module: 'seal_policies',
-		functionName: 'seal_approve',
-	},
+// Note: packageId is not included here as it will be taken from the messaging package config
+export const DEFAULT_SEAL_APPROVE_CONTRACT = {
+	module: 'seal_policies',
+	functionName: 'seal_approve',
 };
 
 export const TESTNET_MESSAGING_PACKAGE_CONFIG = {
-	packageId: process.env.TESTNET_PACKAGE_ID || '0xTBD',
+	packageId: process.env.TESTNET_PACKAGE_ID || FALLBACK_PACKAGE_ID,
 } satisfies MessagingPackageConfig;
 
 export const MAINNET_MESSAGING_PACKAGE_CONFIG = {
-	packageId: process.env.MAINNET_PACKAGE_ID || '0xTBD',
+	packageId: process.env.MAINNET_PACKAGE_ID || FALLBACK_PACKAGE_ID,
 } satisfies MessagingPackageConfig;


### PR DESCRIPTION
If no sealApproveContract is provided in the config, it should use the same packageId, as the one provided for the smart contract in the `packageConfig`.

In our case, I was still trying to use the one in the default constants, which is relying on process.env
process.env is problematic for some frameworks, like vite.

Also, added a fallback packageId, in case devs want to try the sdk without publishing a contract.