### PR TITLE
channel admin adds new members without invitation process

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,7 +21,7 @@
 
 # Scripts
 .env
-.publish.res.json
+.publish.res*.json
 .template_bytecode.json
 
 # Test data and sensitive information

--- a/APIRef.md
+++ b/APIRef.md
@@ -193,6 +193,118 @@ const { channelId, encryptedKeyBytes } = flow.getGeneratedEncryptionKey();
 
 ---
 
+### Add members to channel
+
+**Method:** `addMembers(channelId: string, creatorCapId: string, newMemberAddresses: string[]): Promise<(tx: Transaction) => void>`
+
+**Purpose:** Builds a transaction for adding new members to an existing channel. Only the channel creator can add members.
+
+**Parameters:**
+
+```typescript
+channelId: string;
+creatorCapId: string;
+newMemberAddresses: string[];
+```
+
+**Returns:** A transaction builder function
+
+**Example:**
+
+```typescript
+const tx = new Transaction();
+const addMembersBuilder = await client.messaging.addMembers(
+  channelId,
+  creatorCapId,
+  ["0xabc...", "0xdef..."]
+);
+
+await addMembersBuilder(tx);
+await signer.signAndExecuteTransaction({ transaction: tx });
+```
+
+> [!NOTE]
+> This operation requires the `CreatorCap` for the channel. Only the channel creator can add new members.
+
+---
+
+### Add members transaction
+
+**Method:** `addMembersTransaction(channelId: string, creatorCapId: string, newMemberAddresses: string[]): Promise<Transaction>`
+
+**Purpose:** Creates a transaction for adding new members to a channel. Only the channel creator can add members.
+
+**Parameters:**
+
+```typescript
+channelId: string;
+creatorCapId: string;
+newMemberAddresses: string[];
+```
+
+**Returns:** A `Transaction` object ready to be signed and executed
+
+**Example:**
+
+```typescript
+const tx = await client.messaging.addMembersTransaction(
+  channelId,
+  creatorCapId,
+  ["0xabc...", "0xdef..."]
+);
+
+await signer.signAndExecuteTransaction({ transaction: tx });
+```
+
+> [!NOTE]
+> This operation requires the `CreatorCap` for the channel. Only the channel creator can add new members.
+
+---
+
+### Execute add members transaction
+
+**Method:** `executeAddMembersTransaction(params): Promise<{ digest: string; memberCapIds: string[] }>`
+
+**Purpose:** Adds new members to a channel in a single call. Only the channel creator can add members.
+
+**Parameters:**
+
+```typescript
+{
+  signer: Signer;
+  channelId: string;
+  creatorCapId: string;
+  newMemberAddresses: string[];
+}
+```
+
+**Returns:**
+
+```typescript
+{
+  digest: string;
+  memberCapIds: string[];
+}
+```
+
+**Example:**
+
+```typescript
+const result = await client.messaging.executeAddMembersTransaction({
+  signer,
+  channelId,
+  creatorCapId,
+  newMemberAddresses: ["0xabc...", "0xdef..."]
+});
+
+console.log(`Added ${result.memberCapIds.length} members`);
+```
+
+> [!NOTE]
+> This operation requires the `CreatorCap` for the channel. Only the channel creator can add new members.
+
+---
+
 ## Message management
 
 ### Get channel messages

--- a/Examples.md
+++ b/Examples.md
@@ -188,6 +188,123 @@ for (const msg of messages.messages) {
 
 The AI agent can then engage in the same two-way conversation loop as a human support operator.
 
+## Adding new members to an existing channel
+
+This example shows how a channel creator can add new members to an existing channel. This is useful when you need to expand access to a conversation after the channel has been created.
+
+> [!NOTE]
+> Only the channel creator (the account that has the `CreatorCap`) can add new members to a channel.
+
+### 1. Adding members using the simplified method
+
+The easiest way to add members is using `executeAddMembersTransaction`, which handles the entire process in a single call.
+
+```typescript
+// Assume you have already created a channel and have the channelId and creatorCapId
+const channelId = "0xCHANNEL...";
+const creatorCapId = "0xCREATORCAP...";
+
+// Add two new members to the channel
+const newMemberAddresses = [
+  "0xNEWMEMBER1...",
+  "0xNEWMEMBER2...",
+];
+
+const { digest, memberCapIds } = await messaging.executeAddMembersTransaction({
+  signer: creatorSigner, // Must be the channel creator
+  channelId,
+  creatorCapId,
+  newMemberAddresses,
+});
+
+console.log(`Added ${memberCapIds.length} new members in tx ${digest}`);
+console.log(`New member cap IDs:`, memberCapIds);
+```
+
+### 2. Adding members with transaction builder pattern
+
+For more control over transaction composition, use the transaction builder pattern:
+
+```typescript
+import { Transaction } from "@mysten/sui/transactions";
+
+const tx = new Transaction();
+
+// Build the add members transaction
+const addMembersBuilder = await messaging.addMembers(
+  channelId,
+  creatorCapId,
+  newMemberAddresses
+);
+
+// Add to the transaction
+await addMembersBuilder(tx);
+
+// Sign and execute
+const result = await creatorSigner.signAndExecuteTransaction({
+  transaction: tx,
+});
+
+console.log(`Transaction digest: ${result.digest}`);
+```
+
+### 3. Adding members using direct transaction method
+
+You can also use `addMembersTransaction` which returns a `Transaction` object directly:
+
+```typescript
+const tx = await messaging.addMembersTransaction(
+  channelId,
+  creatorCapId,
+  newMemberAddresses
+);
+
+const result = await creatorSigner.signAndExecuteTransaction({
+  transaction: tx,
+});
+```
+
+### 4. Verifying the new members were added
+
+After adding members, you can verify they were successfully added by fetching the channel members:
+
+```typescript
+const channelMembers = await messaging.getChannelMembers(channelId);
+
+console.log(`Total members: ${channelMembers.members.length}`);
+channelMembers.members.forEach((member) => {
+  console.log(`Member: ${member.memberAddress}`);
+  console.log(`MemberCapId: ${member.memberCapId}`);
+});
+```
+
+### Example: Expanding a support team
+
+Building on the in-app product support example, you might want to add additional support agents to a channel:
+
+```typescript
+// Original support channel with one user
+const { channelId, creatorCapId } = await messaging.executeCreateChannelTransaction({
+  signer: supportSigner,
+  initialMembers: [topUserAddress],
+});
+
+// Later, add more support agents to help with the conversation
+const additionalAgents = [
+  "0xSUPPORT_AGENT_2...",
+  "0xSUPPORT_AGENT_3...",
+];
+
+await messaging.executeAddMembersTransaction({
+  signer: supportSigner,
+  channelId,
+  creatorCapId,
+  newMemberAddresses: additionalAgents,
+});
+
+console.log("Support team expanded successfully");
+```
+
 ## Cross-App Identity & Reputation Updates
 
 This example shows how an identity app (e.g., proof-of-humanity or reputation scoring) can publish updates about a user’s status. Multiple consuming apps, such as DeFi protocols, games, or social platforms, subscribe to those updates via secure messaging channels.
@@ -247,7 +364,7 @@ console.log(`Created reputation updates channel: ${channelId}`);
 ```
 
 > [!NOTE]
-> The SDK does not yet support adding/removing members after creation. Be sure to include all intended subscribers in `initialMembers`.
+> If you need to add more subscribers later, you can use the `addMembers` functionality (see the "Adding new members to an existing channel" example above). Only the channel creator can add new members.
 
 ### 3. Publish an identity/reputation update
 

--- a/packages/.changeset/afraid-pets-add.md
+++ b/packages/.changeset/afraid-pets-add.md
@@ -9,5 +9,3 @@ Expose three new methods following the SDK pattern:
 - addMembers(): Transaction builder
 - addMembersTransaction(): Returns Transaction object
 - executeAddMembersTransaction(): Execute and return results with member details
-
-This allows channel admins to add new members without requiring them to go through an invitation process.

--- a/packages/.changeset/afraid-pets-add.md
+++ b/packages/.changeset/afraid-pets-add.md
@@ -1,0 +1,13 @@
+---
+'@mysten/messaging': minor
+---
+
+Introduce the `addMembers` API to enable channel creators to add members to existing channels
+
+Expose three new methods following the SDK pattern:
+
+- addMembers(): Transaction builder
+- addMembersTransaction(): Returns Transaction object
+- executeAddMembersTransaction(): Execute and return results with member details
+
+This allows channel admins to add new members without requiring them to go through an invitation process.

--- a/packages/messaging/pnpm-lock.yaml
+++ b/packages/messaging/pnpm-lock.yaml
@@ -20,9 +20,6 @@ importers:
       '@mysten/walrus':
         specifier: ^0.8.1
         version: 0.8.1(typescript@5.9.3)
-      '@protobuf-ts/grpcweb-transport':
-        specifier: ^2.11.1
-        version: 2.11.1
     devDependencies:
       '@changesets/cli':
         specifier: ^2.29.6
@@ -39,6 +36,9 @@ importers:
       '@mysten/codegen':
         specifier: ^0.5.7
         version: 0.5.7
+      '@protobuf-ts/grpcweb-transport':
+        specifier: ^2.11.1
+        version: 2.11.1
       '@protobuf-ts/plugin':
         specifier: ^2.11.1
         version: 2.11.1
@@ -61,16 +61,16 @@ importers:
         specifier: ^9.2.0
         version: 9.2.1
       eslint:
-        specifier: ^8.45.0
+        specifier: ^8.57.1
         version: 8.57.1
       eslint-config-prettier:
-        specifier: ^8.8.0
+        specifier: ^8.10.2
         version: 8.10.2(eslint@8.57.1)
       eslint-config-react-app:
         specifier: ^7.0.1
         version: 7.0.1(@babel/plugin-syntax-flow@7.27.1(@babel/core@7.28.4))(@babel/plugin-transform-react-jsx@7.27.1(@babel/core@7.28.4))(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1)(typescript@5.9.3)
       eslint-import-resolver-typescript:
-        specifier: ^3.6.1
+        specifier: ^3.10.1
         version: 3.10.1(eslint-plugin-import@2.32.0)(eslint@8.57.1)
       eslint-plugin-header:
         specifier: ^3.1.1
@@ -88,7 +88,7 @@ importers:
         specifier: ^0.2.17
         version: 0.2.17
       eslint-plugin-unused-imports:
-        specifier: ^3.0.0
+        specifier: ^3.2.0
         version: 3.2.0(@typescript-eslint/eslint-plugin@8.46.2(@typescript-eslint/parser@8.46.2(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1)
       graphql-config:
         specifier: ^5.1.5
@@ -3088,9 +3088,6 @@ packages:
   get-symbol-description@1.1.0:
     resolution: {integrity: sha512-w9UMqWwJxHNOvoNzSJ2oPF5wvYcvP7jUvYzhp67yEhTi17ZDBBC1z9pTdGuzjD+EFIqLSYRweZjqfiPzQ06Ebg==}
     engines: {node: '>= 0.4'}
-
-  get-tsconfig@4.10.1:
-    resolution: {integrity: sha512-auHyJ4AgMz7vgS8Hp3N6HXSmlMdUyhSUrfBF16w153rxtLIEOE+HGqaBppczZvnHLqQJfiHotCYpNhl0lUROFQ==}
 
   get-tsconfig@4.13.0:
     resolution: {integrity: sha512-1VKTZJCwBrvbd+Wn3AOgQP/2Av+TfTCOlE4AcRJE72W1ksZXbAx8PPBR9RzgTeSPzlPMHrbANMH3LbltH73wxQ==}
@@ -7813,7 +7810,7 @@ snapshots:
       '@nolyfill/is-core-module': 1.0.39
       debug: 4.4.3
       eslint: 8.57.1
-      get-tsconfig: 4.10.1
+      get-tsconfig: 4.13.0
       is-bun-module: 2.0.0
       stable-hash: 0.0.5
       tinyglobby: 0.2.15
@@ -8024,7 +8021,7 @@ snapshots:
   eslint@8.57.1:
     dependencies:
       '@eslint-community/eslint-utils': 4.9.0(eslint@8.57.1)
-      '@eslint-community/regexpp': 4.12.1
+      '@eslint-community/regexpp': 4.12.2
       '@eslint/eslintrc': 2.1.4
       '@eslint/js': 8.57.1
       '@humanwhocodes/config-array': 0.13.0
@@ -8249,10 +8246,6 @@ snapshots:
       es-errors: 1.3.0
       get-intrinsic: 1.3.0
 
-  get-tsconfig@4.10.1:
-    dependencies:
-      resolve-pkg-maps: 1.0.0
-
   get-tsconfig@4.13.0:
     dependencies:
       resolve-pkg-maps: 1.0.0
@@ -8440,7 +8433,7 @@ snapshots:
 
   is-bun-module@2.0.0:
     dependencies:
-      semver: 7.7.2
+      semver: 7.7.3
 
   is-callable@1.2.7: {}
 

--- a/packages/messaging/src/types.ts
+++ b/packages/messaging/src/types.ts
@@ -9,6 +9,7 @@ import type {
 import type { SealClient, SessionKey } from '@mysten/seal';
 import type { WalrusClient } from '@mysten/walrus';
 import type { Transaction } from '@mysten/sui/transactions';
+import type { Signer } from '@mysten/sui/cryptography';
 
 import type {
 	AttachmentMetadata,
@@ -85,6 +86,28 @@ export interface CreateChannelFlow {
 		channelId: string;
 		encryptedKeyBytes: Uint8Array<ArrayBuffer>;
 	};
+}
+
+// Add Members interfaces
+export interface AddMembersOptions {
+	channelId: string;
+	memberCapId: string;
+	newMemberAddresses: string[];
+	creatorCapId: string;
+}
+
+export interface AddMembersTransactionOptions extends AddMembersOptions {
+	transaction?: Transaction;
+}
+
+export interface ExecuteAddMembersTransactionOptions extends AddMembersOptions {
+	transaction?: Transaction;
+	signer: Signer;
+}
+
+export interface AddedMemberCap {
+	memberCap: (typeof MemberCap)['$inferType'];
+	ownerAddress: string;
 }
 
 export interface MessagingPackageConfig {

--- a/packages/messaging/test/integration-read-v2.test.ts
+++ b/packages/messaging/test/integration-read-v2.test.ts
@@ -178,7 +178,7 @@ describe('Integration tests - Read Path v2', () => {
 			expect(result.direction).toBe('backward');
 			expect(result.cursor).toBeDefined();
 			expect(typeof result.hasNextPage).toBe('boolean');
-		});
+		}, 10000);
 
 		it('should fetch messages in forward direction (oldest first)', async () => {
 			const client = createTestClient(testSetup.suiClient, testSetup.config, testSetup.signer);
@@ -201,7 +201,7 @@ describe('Integration tests - Read Path v2', () => {
 			expect(result.direction).toBe('forward');
 			expect(result.cursor).toBeDefined();
 			expect(typeof result.hasNextPage).toBe('boolean');
-		});
+		}, 10000);
 
 		it('should handle pagination with cursor', async () => {
 			const client = createTestClient(testSetup.suiClient, testSetup.config, testSetup.signer);
@@ -238,7 +238,7 @@ describe('Integration tests - Read Path v2', () => {
 			const firstPageIds = firstPage.messages.map((m) => m.sender + m.createdAtMs);
 			const secondPageIds = secondPage.messages.map((m) => m.sender + m.createdAtMs);
 			expect(firstPageIds).not.toEqual(secondPageIds);
-		});
+		}, 10000);
 
 		it('should handle empty channels gracefully', async () => {
 			const client = createTestClient(testSetup.suiClient, testSetup.config, testSetup.signer);
@@ -293,7 +293,7 @@ describe('Integration tests - Read Path v2', () => {
 
 			expect(result.messages.length).toBe(0);
 			expect(result.cursor).toBe(pollingState.lastCursor);
-		});
+		}, 10000);
 
 		it('should handle cursor out of bounds', async () => {
 			const client = createTestClient(testSetup.suiClient, testSetup.config, testSetup.signer);
@@ -342,7 +342,7 @@ describe('Integration tests - Read Path v2', () => {
 			expect(decryptedMessage.text).toBeDefined();
 			expect(decryptedMessage.sender).toBeDefined();
 			expect(decryptedMessage.createdAtMs).toBeDefined();
-		});
+		}, 10000);
 
 		it('should handle messages with attachments', async () => {
 			const client = createTestClient(testSetup.suiClient, testSetup.config, testSetup.signer);


### PR DESCRIPTION
Introduce the `addMembers` API to enable channel creators to add members to existing channels

Expose three new methods following the SDK pattern:

- addMembers(): Transaction builder
- addMembersTransaction(): Returns Transaction object
- executeAddMembersTransaction(): Execute and return results with member details

**Internal:**
- Add #deduplicateAddresses() helper for reusable address deduplication
- Add #getCreatedObjectsByType<T>() generic helper to get and parse created objects with owner info
- Refactor #getGeneratedCaps() to use new generic helper
- Refactor createChannelFlow to use deduplication helper
- Fix bug: filter transaction effects to exclude objects with outputState='DoesNotExist'

**Types (types.ts)**
- Add AddMembersOptions interface
- Add AddMembersTransactionOptions interface
- Add ExecuteAddMembersTransactionOptions interface
- Add AddedMemberCap interface with memberCap and ownerAddress

**Test Helpers (test-helpers.ts)**
- Add findChannelMembership() helper with pagination support
- Add getCreatorCapId() helper with pagination support and proper content parsing

**Integration Tests (integration-write.test.ts)**
- Add test suite for adding members functionality
- Remove flaky pagination-dependent assertions