### PR TITLE
[seint-2553] implement a proper logger for the ts sdk

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,3 +53,4 @@ For questions about the SDK, use case discussions, or integration support, conta
 - [SDK API Reference](./APIRef.md)
 - [Integration Testing](./Testing.md)
 - [Example patterns](./Examples.md)
+- [Logging](./logging.md)

--- a/logging.md
+++ b/logging.md
@@ -1,0 +1,319 @@
+# Logging
+
+The Messaging SDK uses [LogTape](https://github.com/dahlia/logtape) for structured logging. Logging is completely optional - the SDK works perfectly without it.
+
+## Overview
+
+LogTape integration follows a library-first design:
+- **Zero configuration required** in the SDK
+- **Optional peer dependency** - install only if you want logging
+- **Full user control** over what gets logged and where
+- **Structured logging** with rich context for debugging
+
+## Installation
+
+Install LogTape as a dependency in your application:
+
+```bash
+npm install @logtape/logtape
+# or
+pnpm add @logtape/logtape
+# or
+yarn add @logtape/logtape
+```
+
+**Note**: LogTape is an optional peer dependency. The Messaging SDK works without it.
+
+## Quick Start
+
+Configure LogTape once at application startup:
+
+```typescript
+import { configure, getConsoleSink } from "@logtape/logtape";
+
+// Configure LogTape before using the Messaging SDK
+await configure({
+  sinks: {
+    console: getConsoleSink(),
+  },
+  loggers: [
+    // Enable all messaging SDK logs at info level
+    {
+      category: ["@mysten/messaging"],
+      level: "info",
+      sinks: ["console"],
+    },
+  ],
+});
+```
+
+## Logging Categories
+
+The SDK uses a hierarchical category structure for fine-grained control:
+
+| Category | Description | Typical Operations |
+|----------|-------------|-------------------|
+| `["@mysten/messaging"]` | Root - captures all SDK logs | All operations |
+| `["@mysten/messaging", "client", "reads"]` | Read operations | `getChannelObjects`, `getChannelMessages`, `getChannelMembers` |
+| `["@mysten/messaging", "client", "writes"]` | Write operations | `executeCreateChannel`, `executeSendMessage`, `executeAddMembers` |
+| `["@mysten/messaging", "encryption"]` | Encryption operations | Key generation, encrypt/decrypt operations |
+| `["@mysten/messaging", "storage"]` | All storage operations | Upload/download to storage adapters |
+| `["@mysten/messaging", "storage", "walrus"]` | Walrus-specific operations | Walrus uploads, downloads, errors |
+
+## Log Levels
+
+The SDK uses four log levels:
+
+- **`debug`**: Detailed diagnostic information (entry points, parameters)
+- **`info`**: Successful operations with key identifiers (channelId, messageId, etc.)
+- **`warning`**: Unexpected but handled situations (partial failures, retries)
+- **`error`**: Operation failures with error context
+
+## Configuration Examples
+
+### Development: Verbose Logging
+
+Log everything at debug level for maximum visibility:
+
+```typescript
+await configure({
+  sinks: {
+    console: getConsoleSink(),
+  },
+  loggers: [
+    {
+      category: ["@mysten/messaging"],
+      level: "debug",
+      sinks: ["console"],
+    },
+  ],
+});
+```
+
+### Production: Errors Only
+
+Log only errors to minimize noise:
+
+```typescript
+await configure({
+  sinks: {
+    console: getConsoleSink(),
+  },
+  loggers: [
+    {
+      category: ["@mysten/messaging"],
+      level: "error",
+      sinks: ["console"],
+    },
+  ],
+});
+```
+
+### Selective Logging
+
+Enable debug logging for specific modules:
+
+```typescript
+await configure({
+  sinks: {
+    console: getConsoleSink(),
+  },
+  loggers: [
+    // Info for all SDK operations
+    {
+      category: ["@mysten/messaging"],
+      level: "info",
+      sinks: ["console"],
+    },
+    // Debug for encryption troubleshooting
+    {
+      category: ["@mysten/messaging", "encryption"],
+      level: "debug",
+      sinks: ["console"],
+    },
+    // Debug for storage troubleshooting
+    {
+      category: ["@mysten/messaging", "storage", "walrus"],
+      level: "debug",
+      sinks: ["console"],
+    },
+  ],
+});
+```
+
+### Multiple Sinks
+
+Send different log levels to different destinations:
+
+```typescript
+import { configure, getConsoleSink, getFileSink } from "@logtape/logtape";
+
+await configure({
+  sinks: {
+    console: getConsoleSink(),
+    errorFile: getFileSink("errors.log"),
+  },
+  loggers: [
+    // All logs to console
+    {
+      category: ["@mysten/messaging"],
+      level: "info",
+      sinks: ["console"],
+    },
+    // Errors to file
+    {
+      category: ["@mysten/messaging"],
+      level: "error",
+      sinks: ["errorFile"],
+    },
+  ],
+});
+```
+
+## What Gets Logged
+
+### Read Operations
+
+**Debug level:**
+- Entry parameters (channelId, userAddress, cursor, limit)
+- Query details
+
+**Info level:**
+- Retrieved channelIds
+- Message counts and pagination state
+- MemberCap IDs
+
+**Example:**
+```json
+{
+  "level": "info",
+  "category": ["@mysten/messaging", "client", "reads"],
+  "message": "Retrieved channel messages",
+  "properties": {
+    "channelId": "0x...",
+    "messagesTableId": "0x...",
+    "messageCount": 10,
+    "fetchRange": "0-10",
+    "cursor": 10,
+    "hasNextPage": true,
+    "direction": "backward"
+  }
+}
+```
+
+### Write Operations
+
+**Debug level:**
+- Operation parameters (addresses, counts)
+- Transaction building details
+
+**Info level:**
+- Created object IDs (channelId, messageId, creatorCapId)
+- Transaction digests
+- Member counts
+
+**Example:**
+```json
+{
+  "level": "info",
+  "category": ["@mysten/messaging", "client", "writes"],
+  "message": "Channel created",
+  "properties": {
+    "channelId": "0x...",
+    "creatorCapId": "0x...",
+    "creatorAddress": "0x...",
+    "memberCount": 3,
+    "digest": "0x..."
+  }
+}
+```
+
+### Encryption Operations
+
+**Debug level:**
+- Key generation events
+- Encryption/decryption operations with payload sizes
+- No sensitive data (keys or decrypted content)
+
+### Storage Operations
+
+**Debug level:**
+- Upload/download initiation with counts and URLs
+- Blob IDs and sizes
+
+**Info level:**
+- Successful uploads with blob IDs
+- Download completion with byte counts
+
+**Error level:**
+- Upload failures with HTTP status and error text
+- Network errors
+
+## Security Considerations
+
+The SDK **never logs**:
+- Raw encryption keys (session keys, symmetric keys, private keys)
+- Decrypted message content
+- Decrypted attachment data
+- Private key material
+
+The SDK **does log**:
+- Object IDs (channels, messages, caps) - these are public on-chain
+- Payload lengths (not content)
+- Public keys
+- Operation metadata (counts, timestamps)
+- Error messages (from `Error.message` - may contain sensitive info in stack traces)
+
+**Important**: Error messages are logged as-is from exceptions. Review your error logs to ensure no sensitive data is exposed. Consider using LogTape's [redaction features](https://jsr.io/@logtape/logtape/doc/redaction/~) if needed.
+
+## Troubleshooting
+
+### Logs Not Appearing
+
+1. **Verify LogTape is configured**:
+   ```typescript
+   await configure({ /* ... */ });
+   ```
+   Call this before using the Messaging SDK.
+
+2. **Check log level**:
+   Ensure the category's `level` is low enough to capture logs.
+   Example: `"debug"` captures everything, `"error"` only errors.
+
+3. **Verify category matches**:
+   Use `["@mysten/messaging"]` to capture all SDK logs.
+
+### Too Many Logs
+
+1. **Increase log level**:
+   Change from `"debug"` to `"info"` or `"warning"`.
+
+2. **Add filters**:
+   ```typescript
+   {
+     category: ["@mysten/messaging"],
+     level: "info",
+     filters: [(record) => record.properties.channelId === "0x..."],
+     sinks: ["console"],
+   }
+   ```
+
+3. **Target specific categories**:
+   Only enable logging for modules you're debugging.
+
+## Advanced Usage
+
+For advanced LogTape features such as:
+- Request tracing with implicit contexts
+- Custom sinks and formatters
+- Data redaction
+- Integration with monitoring systems
+- Performance optimization
+
+Please refer to the [LogTape Documentation](https://jsr.io/@logtape/logtape).
+
+## Further Reading
+
+- [LogTape Documentation](https://jsr.io/@logtape/logtape)
+- [LogTape GitHub](https://github.com/dahlia/logtape)
+- [Messaging SDK API Documentation](./README.md)

--- a/logging.md
+++ b/logging.md
@@ -2,17 +2,9 @@
 
 The Messaging SDK uses [LogTape](https://github.com/dahlia/logtape) for structured logging. Logging is completely optional - the SDK works perfectly without it.
 
-## Overview
-
-LogTape integration follows a library-first design:
-- **Zero configuration required** in the SDK
-- **Optional peer dependency** - install only if you want logging
-- **Full user control** over what gets logged and where
-- **Structured logging** with rich context for debugging
-
 ## Installation
 
-Install LogTape as a dependency in your application:
+If you want logging, install LogTape:
 
 ```bash
 npm install @logtape/logtape
@@ -22,43 +14,55 @@ pnpm add @logtape/logtape
 yarn add @logtape/logtape
 ```
 
-**Note**: LogTape is an optional peer dependency. The Messaging SDK works without it.
-
 ## Quick Start
 
 Configure LogTape once at application startup:
 
 ```typescript
 import { configure, getConsoleSink } from "@logtape/logtape";
+import { CATEGORIES } from "@mysten/messaging";
 
 // Configure LogTape before using the Messaging SDK
 await configure({
   sinks: {
     console: getConsoleSink(),
   },
+  filters: {},
   loggers: [
     // Enable all messaging SDK logs at info level
     {
-      category: ["@mysten/messaging"],
-      level: "info",
+      category: CATEGORIES.ROOT,
+      lowestLevel: "info",
       sinks: ["console"],
     },
   ],
 });
 ```
 
+**Tips**:
+- **Use `CATEGORIES` constants**: Import and use the `CATEGORIES` constants instead of manually writing category arrays (e.g., `["@mysten/messaging"]`). This prevents typos and provides better IDE autocomplete.
+- **Production logging**: For production environments, consider using the JSON Lines formatter for machine-readable structured logs:
+  ```typescript
+  import { getConsoleSink, getJsonLinesFormatter } from "@logtape/logtape";
+
+  const console = getConsoleSink({ formatter: getJsonLinesFormatter() });
+  ```
+  This outputs one JSON object per line, making it easy to integrate with log aggregation systems like ELK, Datadog, or CloudWatch.
+
 ## Logging Categories
 
 The SDK uses a hierarchical category structure for fine-grained control:
 
-| Category | Description | Typical Operations |
-|----------|-------------|-------------------|
-| `["@mysten/messaging"]` | Root - captures all SDK logs | All operations |
-| `["@mysten/messaging", "client", "reads"]` | Read operations | `getChannelObjects`, `getChannelMessages`, `getChannelMembers` |
-| `["@mysten/messaging", "client", "writes"]` | Write operations | `executeCreateChannel`, `executeSendMessage`, `executeAddMembers` |
-| `["@mysten/messaging", "encryption"]` | Encryption operations | Key generation, encrypt/decrypt operations |
-| `["@mysten/messaging", "storage"]` | All storage operations | Upload/download to storage adapters |
-| `["@mysten/messaging", "storage", "walrus"]` | Walrus-specific operations | Walrus uploads, downloads, errors |
+| Constant | Category | Description | Typical Operations |
+|----------|----------|-------------|-------------------|
+| `CATEGORIES.ROOT` | `["@mysten/messaging"]` | Root - captures all SDK logs | All operations |
+| `CATEGORIES.CLIENT_READS` | `["@mysten/messaging", "client", "reads"]` | Read operations | `getChannelObjects`, `getChannelMessages`, `getChannelMembers` |
+| `CATEGORIES.CLIENT_WRITES` | `["@mysten/messaging", "client", "writes"]` | Write operations | `executeCreateChannel`, `executeSendMessage`, `executeAddMembers` |
+| `CATEGORIES.ENCRYPTION` | `["@mysten/messaging", "encryption"]` | Encryption operations | Key generation, encrypt/decrypt operations |
+| `CATEGORIES.STORAGE` | `["@mysten/messaging", "storage"]` | All storage operations | Upload/download to storage adapters |
+| `CATEGORIES.STORAGE_WALRUS` | `["@mysten/messaging", "storage", "walrus"]` | Walrus-specific operations | Walrus uploads, downloads, errors |
+
+**Recommended**: Use the `CATEGORIES` constants (imported from `"@mysten/messaging"`) in your configuration for type safety and autocompletion.
 
 ## Log Levels
 
@@ -76,14 +80,17 @@ The SDK uses four log levels:
 Log everything at debug level for maximum visibility:
 
 ```typescript
+import { CATEGORIES } from "@mysten/messaging";
+
 await configure({
   sinks: {
     console: getConsoleSink(),
   },
+  filters: {},
   loggers: [
     {
-      category: ["@mysten/messaging"],
-      level: "debug",
+      category: CATEGORIES.ROOT,
+      lowestLevel: "debug",
       sinks: ["console"],
     },
   ],
@@ -95,14 +102,17 @@ await configure({
 Log only errors to minimize noise:
 
 ```typescript
+import { CATEGORIES } from "@mysten/messaging";
+
 await configure({
   sinks: {
     console: getConsoleSink(),
   },
+  filters: {},
   loggers: [
     {
-      category: ["@mysten/messaging"],
-      level: "error",
+      category: CATEGORIES.ROOT,
+      lowestLevel: "error",
       sinks: ["console"],
     },
   ],
@@ -114,27 +124,30 @@ await configure({
 Enable debug logging for specific modules:
 
 ```typescript
+import { CATEGORIES } from "@mysten/messaging";
+
 await configure({
   sinks: {
     console: getConsoleSink(),
   },
+  filters: {},
   loggers: [
     // Info for all SDK operations
     {
-      category: ["@mysten/messaging"],
-      level: "info",
+      category: CATEGORIES.ROOT,
+      lowestLevel: "info",
       sinks: ["console"],
     },
     // Debug for encryption troubleshooting
     {
-      category: ["@mysten/messaging", "encryption"],
-      level: "debug",
+      category: CATEGORIES.ENCRYPTION,
+      lowestLevel: "debug",
       sinks: ["console"],
     },
     // Debug for storage troubleshooting
     {
-      category: ["@mysten/messaging", "storage", "walrus"],
-      level: "debug",
+      category: CATEGORIES.STORAGE_WALRUS,
+      lowestLevel: "debug",
       sinks: ["console"],
     },
   ],
@@ -147,23 +160,25 @@ Send different log levels to different destinations:
 
 ```typescript
 import { configure, getConsoleSink, getFileSink } from "@logtape/logtape";
+import { CATEGORIES } from "@mysten/messaging";
 
 await configure({
   sinks: {
     console: getConsoleSink(),
     errorFile: getFileSink("errors.log"),
   },
+  filters: {},
   loggers: [
     // All logs to console
     {
-      category: ["@mysten/messaging"],
-      level: "info",
+      category: CATEGORIES.ROOT,
+      lowestLevel: "info",
       sinks: ["console"],
     },
     // Errors to file
     {
-      category: ["@mysten/messaging"],
-      level: "error",
+      category: CATEGORIES.ROOT,
+      lowestLevel: "error",
       sinks: ["errorFile"],
     },
   ],
@@ -277,11 +292,11 @@ The SDK **does log**:
    Call this before using the Messaging SDK.
 
 2. **Check log level**:
-   Ensure the category's `level` is low enough to capture logs.
+   Ensure the category's `lowestLevel` is low enough to capture logs.
    Example: `"debug"` captures everything, `"error"` only errors.
 
 3. **Verify category matches**:
-   Use `["@mysten/messaging"]` to capture all SDK logs.
+   Use `CATEGORIES.ROOT` (or `["@mysten/messaging"]`) to capture all SDK logs.
 
 ### Too Many Logs
 

--- a/logging.md
+++ b/logging.md
@@ -273,13 +273,13 @@ The SDK **never logs**:
 - Private key material
 
 The SDK **does log**:
-- Object IDs (channels, messages, caps) - these are public on-chain
-- Payload lengths (not content)
-- Public keys
-- Operation metadata (counts, timestamps)
-- Error messages (from `Error.message` - may contain sensitive info in stack traces)
+- **Object IDs** (channels, messages, member caps) - these are public on-chain
+- **Sender and member addresses** - these are public on-chain
+- **Payload lengths** (not the actual content)
+- **Operation metadata** (counts, timestamps, blob IDs)
+- **Error messages** (from `Error.message`) - may contain sensitive information in stack traces
 
-**Important**: Error messages are logged as-is from exceptions. Review your error logs to ensure no sensitive data is exposed. Consider using LogTape's [redaction features](https://www.npmjs.com/package/@logtape/logtape/doc/redaction/~) if needed.
+**Important**: Error messages are logged as-is from caught exceptions. Review your error logs to ensure no sensitive data is inadvertently exposed through error messages. Consider using LogTape's [redaction features](https://www.npmjs.com/package/@logtape/logtape) if you need to sanitize logs before sending to external systems.
 
 ## Troubleshooting
 

--- a/logging.md
+++ b/logging.md
@@ -20,7 +20,7 @@ Configure LogTape once at application startup:
 
 ```typescript
 import { configure, getConsoleSink } from "@logtape/logtape";
-import { CATEGORIES } from "@mysten/messaging";
+import { LOG_CATEGORIES } from "@mysten/messaging";
 
 // Configure LogTape before using the Messaging SDK
 await configure({
@@ -31,7 +31,7 @@ await configure({
   loggers: [
     // Enable all messaging SDK logs at info level
     {
-      category: CATEGORIES.ROOT,
+      category: LOG_CATEGORIES.ROOT,
       lowestLevel: "info",
       sinks: ["console"],
     },
@@ -40,7 +40,7 @@ await configure({
 ```
 
 **Tips**:
-- **Use `CATEGORIES` constants**: Import and use the `CATEGORIES` constants instead of manually writing category arrays (e.g., `["@mysten/messaging"]`). This prevents typos and provides better IDE autocomplete.
+- **Use `LOG_CATEGORIES` constants**: Import and use the `LOG_CATEGORIES` constants instead of manually writing category arrays (e.g., `["@mysten/messaging"]`). This prevents typos and provides better IDE autocomplete.
 - **Production logging**: For production environments, consider using the JSON Lines formatter for machine-readable structured logs:
   ```typescript
   import { getConsoleSink, getJsonLinesFormatter } from "@logtape/logtape";
@@ -55,14 +55,14 @@ The SDK uses a hierarchical category structure for fine-grained control:
 
 | Constant | Category | Description | Typical Operations |
 |----------|----------|-------------|-------------------|
-| `CATEGORIES.ROOT` | `["@mysten/messaging"]` | Root - captures all SDK logs | All operations |
-| `CATEGORIES.CLIENT_READS` | `["@mysten/messaging", "client", "reads"]` | Read operations | `getChannelObjects`, `getChannelMessages`, `getChannelMembers` |
-| `CATEGORIES.CLIENT_WRITES` | `["@mysten/messaging", "client", "writes"]` | Write operations | `executeCreateChannel`, `executeSendMessage`, `executeAddMembers` |
-| `CATEGORIES.ENCRYPTION` | `["@mysten/messaging", "encryption"]` | Encryption operations | Key generation, encrypt/decrypt operations |
-| `CATEGORIES.STORAGE` | `["@mysten/messaging", "storage"]` | All storage operations | Upload/download to storage adapters |
-| `CATEGORIES.STORAGE_WALRUS` | `["@mysten/messaging", "storage", "walrus"]` | Walrus-specific operations | Walrus uploads, downloads, errors |
+| `LOG_CATEGORIES.ROOT` | `["@mysten/messaging"]` | Root - captures all SDK logs | All operations |
+| `LOG_CATEGORIES.CLIENT_READS` | `["@mysten/messaging", "client", "reads"]` | Read operations | `getChannelObjects`, `getChannelMessages`, `getChannelMembers` |
+| `LOG_CATEGORIES.CLIENT_WRITES` | `["@mysten/messaging", "client", "writes"]` | Write operations | `executeCreateChannel`, `executeSendMessage`, `executeAddMembers` |
+| `LOG_CATEGORIES.ENCRYPTION` | `["@mysten/messaging", "encryption"]` | Encryption operations | Key generation, encrypt/decrypt operations |
+| `LOG_CATEGORIES.STORAGE` | `["@mysten/messaging", "storage"]` | All storage operations | Upload/download to storage adapters |
+| `LOG_CATEGORIES.STORAGE_WALRUS` | `["@mysten/messaging", "storage", "walrus"]` | Walrus-specific operations | Walrus uploads, downloads, errors |
 
-**Recommended**: Use the `CATEGORIES` constants (imported from `"@mysten/messaging"`) in your configuration for type safety and autocompletion.
+**Recommended**: Use the `LOG_CATEGORIES` constants (imported from `"@mysten/messaging"`) in your configuration for type safety and autocompletion.
 
 ## Log Levels
 
@@ -80,7 +80,7 @@ The SDK uses four log levels:
 Log everything at debug level for maximum visibility:
 
 ```typescript
-import { CATEGORIES } from "@mysten/messaging";
+import { LOG_CATEGORIES } from "@mysten/messaging";
 
 await configure({
   sinks: {
@@ -89,7 +89,7 @@ await configure({
   filters: {},
   loggers: [
     {
-      category: CATEGORIES.ROOT,
+      category: LOG_CATEGORIES.ROOT,
       lowestLevel: "debug",
       sinks: ["console"],
     },
@@ -102,7 +102,7 @@ await configure({
 Log only errors to minimize noise:
 
 ```typescript
-import { CATEGORIES } from "@mysten/messaging";
+import { LOG_CATEGORIES } from "@mysten/messaging";
 
 await configure({
   sinks: {
@@ -111,7 +111,7 @@ await configure({
   filters: {},
   loggers: [
     {
-      category: CATEGORIES.ROOT,
+      category: LOG_CATEGORIES.ROOT,
       lowestLevel: "error",
       sinks: ["console"],
     },
@@ -124,7 +124,7 @@ await configure({
 Enable debug logging for specific modules:
 
 ```typescript
-import { CATEGORIES } from "@mysten/messaging";
+import { LOG_CATEGORIES } from "@mysten/messaging";
 
 await configure({
   sinks: {
@@ -134,19 +134,19 @@ await configure({
   loggers: [
     // Info for all SDK operations
     {
-      category: CATEGORIES.ROOT,
+      category: LOG_CATEGORIES.ROOT,
       lowestLevel: "info",
       sinks: ["console"],
     },
     // Debug for encryption troubleshooting
     {
-      category: CATEGORIES.ENCRYPTION,
+      category: LOG_CATEGORIES.ENCRYPTION,
       lowestLevel: "debug",
       sinks: ["console"],
     },
     // Debug for storage troubleshooting
     {
-      category: CATEGORIES.STORAGE_WALRUS,
+      category: LOG_CATEGORIES.STORAGE_WALRUS,
       lowestLevel: "debug",
       sinks: ["console"],
     },
@@ -160,7 +160,7 @@ Send different log levels to different destinations:
 
 ```typescript
 import { configure, getConsoleSink, getFileSink } from "@logtape/logtape";
-import { CATEGORIES } from "@mysten/messaging";
+import { LOG_CATEGORIES } from "@mysten/messaging";
 
 await configure({
   sinks: {
@@ -171,13 +171,13 @@ await configure({
   loggers: [
     // All logs to console
     {
-      category: CATEGORIES.ROOT,
+      category: LOG_CATEGORIES.ROOT,
       lowestLevel: "info",
       sinks: ["console"],
     },
     // Errors to file
     {
-      category: CATEGORIES.ROOT,
+      category: LOG_CATEGORIES.ROOT,
       lowestLevel: "error",
       sinks: ["errorFile"],
     },
@@ -279,7 +279,7 @@ The SDK **does log**:
 - Operation metadata (counts, timestamps)
 - Error messages (from `Error.message` - may contain sensitive info in stack traces)
 
-**Important**: Error messages are logged as-is from exceptions. Review your error logs to ensure no sensitive data is exposed. Consider using LogTape's [redaction features](https://jsr.io/@logtape/logtape/doc/redaction/~) if needed.
+**Important**: Error messages are logged as-is from exceptions. Review your error logs to ensure no sensitive data is exposed. Consider using LogTape's [redaction features](https://www.npmjs.com/package/@logtape/logtape/doc/redaction/~) if needed.
 
 ## Troubleshooting
 
@@ -296,7 +296,7 @@ The SDK **does log**:
    Example: `"debug"` captures everything, `"error"` only errors.
 
 3. **Verify category matches**:
-   Use `CATEGORIES.ROOT` (or `["@mysten/messaging"]`) to capture all SDK logs.
+   Use `LOG_CATEGORIES.ROOT` (or `["@mysten/messaging"]`) to capture all SDK logs.
 
 ### Too Many Logs
 
@@ -325,10 +325,10 @@ For advanced LogTape features such as:
 - Integration with monitoring systems
 - Performance optimization
 
-Please refer to the [LogTape Documentation](https://jsr.io/@logtape/logtape).
+Please refer to the [LogTape Documentation](https://www.npmjs.com/package/@logtape/logtape).
 
 ## Further Reading
 
-- [LogTape Documentation](https://jsr.io/@logtape/logtape)
+- [LogTape Documentation](https://www.npmjs.com/package/@logtape/logtape)
 - [LogTape GitHub](https://github.com/dahlia/logtape)
 - [Messaging SDK API Documentation](./README.md)

--- a/packages/.changeset/cozy-shoes-turn.md
+++ b/packages/.changeset/cozy-shoes-turn.md
@@ -1,0 +1,16 @@
+---
+'@mysten/messaging': patch
+---
+
+Add optional LogTape structured logging support
+
+The Messaging SDK now includes structured logging using LogTape.
+This is completely optional - install and configure LogTape in your application to enable logging.
+
+Key features:
+
+- Optional peer dependency
+- Hierarchical logging categories
+- Four log levels: debug, info, warning, error
+
+For setup and configuration, see [loggin.md](./logging.md).

--- a/packages/messaging/package.json
+++ b/packages/messaging/package.json
@@ -52,21 +52,13 @@
 	},
 	"homepage": "https://github.com/MystenLabs/sui-stack-messaging-sdk#readme",
 	"dependencies": {
+		"@logtape/logtape": "^1.2.0",
 		"@mysten/bcs": "^1.9.2",
 		"@mysten/seal": "^0.9.6",
 		"@mysten/sui": "^1.45.2",
 		"@mysten/walrus": "^0.8.6"
 	},
-	"peerDependencies": {
-		"@logtape/logtape": "^1.2.0"
-	},
-	"peerDependenciesMeta": {
-		"@logtape/logtape": {
-			"optional": true
-		}
-	},
 	"devDependencies": {
-		"@logtape/logtape": "^1.2.0",
 		"@changesets/cli": "^2.29.6",
 		"@ianvs/prettier-plugin-sort-imports": "^4.7.0",
 		"@manypkg/cli": "^0.25.1",

--- a/packages/messaging/package.json
+++ b/packages/messaging/package.json
@@ -57,7 +57,16 @@
 		"@mysten/sui": "^1.45.2",
 		"@mysten/walrus": "^0.8.6"
 	},
+	"peerDependencies": {
+		"@logtape/logtape": "^1.2.0"
+	},
+	"peerDependenciesMeta": {
+		"@logtape/logtape": {
+			"optional": true
+		}
+	},
 	"devDependencies": {
+		"@logtape/logtape": "^1.2.0",
 		"@changesets/cli": "^2.29.6",
 		"@ianvs/prettier-plugin-sort-imports": "^4.7.0",
 		"@manypkg/cli": "^0.25.1",

--- a/packages/messaging/pnpm-lock.yaml
+++ b/packages/messaging/pnpm-lock.yaml
@@ -27,6 +27,9 @@ importers:
       '@ianvs/prettier-plugin-sort-imports':
         specifier: ^4.7.0
         version: 4.7.0(prettier@3.6.2)
+      '@logtape/logtape':
+        specifier: ^1.2.0
+        version: 1.2.0
       '@manypkg/cli':
         specifier: ^0.25.1
         version: 0.25.1
@@ -1451,6 +1454,9 @@ packages:
 
   '@js-sdsl/ordered-map@4.4.2':
     resolution: {integrity: sha512-iUKgm52T8HOE/makSxjqoWhe95ZJA1/G1sYsGev2JDKUSS14KAgg1LHb+Ba+IPow0xflbnSkOsZcO08C7w1gYw==}
+
+  '@logtape/logtape@1.2.0':
+    resolution: {integrity: sha512-L7aXBYrxpSUQcsZm/hCuh5REN+dckxmPmH7x7eCROiLAHUSPzc7AhbsxsZLDsXMM4ggtbmS3sUQVa+blfF4sZA==}
 
   '@manypkg/cli@0.25.1':
     resolution: {integrity: sha512-lag906FyiNxzZjsRErkUD5/to174I2JzPk5bZubuJp6loMKKJn73zrtqeU7nHlVkHBg3tgXDTJj22HxUDxLRXw==}
@@ -6222,6 +6228,8 @@ snapshots:
       '@jridgewell/sourcemap-codec': 1.5.5
 
   '@js-sdsl/ordered-map@4.4.2': {}
+
+  '@logtape/logtape@1.2.0': {}
 
   '@manypkg/cli@0.25.1':
     dependencies:

--- a/packages/messaging/src/client.ts
+++ b/packages/messaging/src/client.ts
@@ -435,7 +435,10 @@ export class SuiStackMessagingClient {
 						decryptedChannel.last_message = decryptedMessage;
 					} catch (error) {
 						// If decryption fails, set last_message to null
-						console.warn(`Failed to decrypt last message for channel ${channel.id.id}:`, error);
+						logger.warn('Failed to decrypt last message for channel', {
+							channelId: channel.id.id,
+							error: error instanceof Error ? error.message : String(error),
+						});
 						decryptedChannel.last_message = null;
 					}
 				}
@@ -488,7 +491,10 @@ export class SuiStackMessagingClient {
 		const members: ChannelMember[] = [];
 		for (const obj of memberCapObjects.objects) {
 			if (obj instanceof Error || !obj.content) {
-				console.warn('Failed to fetch MemberCap object:', obj);
+				logger.warn('Failed to fetch MemberCap object', {
+					channelId,
+					error: obj instanceof Error ? obj.message : 'No content in object',
+				});
 				continue;
 			}
 
@@ -503,10 +509,16 @@ export class SuiStackMessagingClient {
 					} else if (obj.owner.$kind === 'ObjectOwner') {
 						// For object-owned MemberCaps, we can't easily get the address
 						// This is a limitation of the current approach
-						console.warn('MemberCap is object-owned, skipping:', memberCap.id.id);
+						logger.warn('MemberCap is object-owned, skipping', {
+							channelId,
+							memberCapId: memberCap.id.id,
+						});
 						continue;
 					} else {
-						console.warn('MemberCap has unknown ownership type:', obj.owner);
+						logger.warn('MemberCap has unknown ownership type', {
+							channelId,
+							ownerKind: obj.owner.$kind,
+						});
 						continue;
 					}
 
@@ -516,7 +528,10 @@ export class SuiStackMessagingClient {
 					});
 				}
 			} catch (error) {
-				console.warn('Failed to parse MemberCap object:', error);
+				logger.warn('Failed to parse MemberCap object', {
+					channelId,
+					error: error instanceof Error ? error.message : String(error),
+				});
 			}
 		}
 
@@ -593,7 +608,11 @@ export class SuiStackMessagingClient {
 				try {
 					return await this.#decryptMessage(message, channelId, memberCapId, encryptedKey);
 				} catch (error) {
-					console.warn(`Failed to decrypt message in channel ${channelId}:`, error);
+					logger.warn('Failed to decrypt message in channel', {
+						channelId,
+						sender: message.sender,
+						error: error instanceof Error ? error.message : String(error),
+					});
 					// Return a placeholder for failed decryption
 					return {
 						text: '[Failed to decrypt message]',

--- a/packages/messaging/src/client.ts
+++ b/packages/messaging/src/client.ts
@@ -8,7 +8,7 @@ import { bcs } from '@mysten/sui/bcs';
 import type { Experimental_SuiClientTypes } from '@mysten/sui/experimental';
 import type { SessionKey } from '@mysten/seal';
 
-import { getLogger, CATEGORIES } from './logging/index.js';
+import { getLogger, LOG_CATEGORIES } from './logging/index.js';
 
 import {
 	_new as newChannel,
@@ -390,7 +390,7 @@ export class SuiStackMessagingClient {
 	async getChannelObjectsByChannelIds(
 		request: GetChannelObjectsByChannelIdsRequest,
 	): Promise<DecryptedChannelObject[]> {
-		const logger = getLogger(CATEGORIES.CLIENT_READS);
+		const logger = getLogger(LOG_CATEGORIES.CLIENT_READS);
 		const { channelIds, userAddress, memberCapIds } = request;
 
 		logger.debug('Fetching channel objects by IDs', {
@@ -462,7 +462,7 @@ export class SuiStackMessagingClient {
 	 * @returns Channel members with addresses and member cap IDs
 	 */
 	async getChannelMembers(channelId: string): Promise<ChannelMembersResponse> {
-		const logger = getLogger(CATEGORIES.CLIENT_READS);
+		const logger = getLogger(LOG_CATEGORIES.CLIENT_READS);
 		logger.debug('Fetching channel members', { channelId });
 
 		// 1. Get the channel object to access the auth structure
@@ -556,7 +556,7 @@ export class SuiStackMessagingClient {
 		limit = 50,
 		direction = 'backward',
 	}: GetChannelMessagesRequest): Promise<DecryptedMessagesResponse> {
-		const logger = getLogger(CATEGORIES.CLIENT_READS);
+		const logger = getLogger(LOG_CATEGORIES.CLIENT_READS);
 		logger.debug('Fetching channel messages', { channelId, userAddress, cursor, limit, direction });
 
 		// 1. Get channel metadata (we need the raw channel object for metadata, not decrypted)
@@ -728,7 +728,7 @@ export class SuiStackMessagingClient {
 		initialMemberAddresses,
 	}: CreateChannelFlowOpts): CreateChannelFlow {
 		const build = () => {
-			const logger = getLogger(CATEGORIES.CLIENT_WRITES);
+			const logger = getLogger(LOG_CATEGORIES.CLIENT_WRITES);
 			const tx = new Transaction();
 			const config = tx.add(noneConfig());
 			const [channel, creatorCap, creatorMemberCap] = tx.add(newChannel({ arguments: { config } }));
@@ -1024,7 +1024,7 @@ export class SuiStackMessagingClient {
 		encryptedKey: EncryptedSymmetricKey;
 		attachments?: File[];
 	} & { signer: Signer }): Promise<{ digest: string; messageId: string }> {
-		const logger = getLogger(CATEGORIES.CLIENT_WRITES);
+		const logger = getLogger(LOG_CATEGORIES.CLIENT_WRITES);
 		const senderAddress = signer.toSuiAddress();
 		logger.debug('Sending message', {
 			channelId,
@@ -1078,7 +1078,7 @@ export class SuiStackMessagingClient {
 	 */
 	addMembers({ channelId, memberCapId, newMemberAddresses, creatorCapId }: AddMembersOptions) {
 		return async (tx: Transaction) => {
-			const logger = getLogger(CATEGORIES.CLIENT_WRITES);
+			const logger = getLogger(LOG_CATEGORIES.CLIENT_WRITES);
 
 			// Deduplicate addresses
 			const uniqueAddresses = this.#deduplicateAddresses(newMemberAddresses);
@@ -1173,7 +1173,7 @@ export class SuiStackMessagingClient {
 		digest: string;
 		addedMembers: AddedMemberCap[];
 	}> {
-		const logger = getLogger(CATEGORIES.CLIENT_WRITES);
+		const logger = getLogger(LOG_CATEGORIES.CLIENT_WRITES);
 		logger.debug('Adding members to channel', {
 			channelId: options.channelId,
 			newMemberAddresses: options.newMemberAddresses,
@@ -1254,7 +1254,7 @@ export class SuiStackMessagingClient {
 		creatorCapId: string;
 		encryptedKeyBytes: Uint8Array<ArrayBuffer>;
 	}> {
-		const logger = getLogger(CATEGORIES.CLIENT_WRITES);
+		const logger = getLogger(LOG_CATEGORIES.CLIENT_WRITES);
 		const creatorAddress = signer.toSuiAddress();
 		logger.debug('Creating channel', {
 			creatorAddress,

--- a/packages/messaging/src/client.ts
+++ b/packages/messaging/src/client.ts
@@ -8,6 +8,8 @@ import { bcs } from '@mysten/sui/bcs';
 import type { Experimental_SuiClientTypes } from '@mysten/sui/experimental';
 import type { SessionKey } from '@mysten/seal';
 
+import { getLogger, CATEGORIES } from './logging/index.js';
+
 import {
 	_new as newChannel,
 	addEncryptedKey,
@@ -388,7 +390,10 @@ export class SuiStackMessagingClient {
 	async getChannelObjectsByChannelIds(
 		request: GetChannelObjectsByChannelIdsRequest,
 	): Promise<DecryptedChannelObject[]> {
+		const logger = getLogger(CATEGORIES.CLIENT_READS);
 		const { channelIds, userAddress, memberCapIds } = request;
+
+		logger.debug('Fetching channel objects by IDs', { channelCount: channelIds.length, userAddress });
 
 		const channelObjectsRes = await this.#suiClient.core.getObjects({
 			objectIds: channelIds,
@@ -436,6 +441,12 @@ export class SuiStackMessagingClient {
 			}),
 		);
 
+		logger.info('Retrieved channel objects', {
+			channelCount: decryptedChannels.length,
+			channelIds: decryptedChannels.map((c) => c.id.id),
+			userAddress,
+		});
+
 		return decryptedChannels;
 	}
 
@@ -445,6 +456,9 @@ export class SuiStackMessagingClient {
 	 * @returns Channel members with addresses and member cap IDs
 	 */
 	async getChannelMembers(channelId: string): Promise<ChannelMembersResponse> {
+		const logger = getLogger(CATEGORIES.CLIENT_READS);
+		logger.debug('Fetching channel members', { channelId });
+
 		// 1. Get the channel object to access the auth structure
 		const channelObjectsRes = await this.#suiClient.core.getObjects({
 			objectIds: [channelId],
@@ -503,6 +517,12 @@ export class SuiStackMessagingClient {
 			}
 		}
 
+		logger.info('Retrieved channel members', {
+			channelId,
+			memberCount: members.length,
+			memberCapIds: members.map((m) => m.memberCapId),
+		});
+
 		return { members };
 	}
 
@@ -518,6 +538,9 @@ export class SuiStackMessagingClient {
 		limit = 50,
 		direction = 'backward',
 	}: GetChannelMessagesRequest): Promise<DecryptedMessagesResponse> {
+		const logger = getLogger(CATEGORIES.CLIENT_READS);
+		logger.debug('Fetching channel messages', { channelId, userAddress, cursor, limit, direction });
+
 		// 1. Get channel metadata (we need the raw channel object for metadata, not decrypted)
 		const channelObjectsRes = await this.#suiClient.core.getObjects({
 			objectIds: [channelId],
@@ -587,6 +610,16 @@ export class SuiStackMessagingClient {
 		});
 
 		// 8. Create response
+		logger.info('Retrieved channel messages', {
+			channelId,
+			messagesTableId,
+			messageCount: decryptedMessages.length,
+			fetchRange: `${fetchRange.startIndex}-${fetchRange.endIndex}`,
+			cursor: nextPagination.cursor,
+			hasNextPage: nextPagination.hasNextPage,
+			direction,
+		});
+
 		return {
 			messages: decryptedMessages,
 			cursor: nextPagination.cursor,
@@ -963,11 +996,21 @@ export class SuiStackMessagingClient {
 		encryptedKey: EncryptedSymmetricKey;
 		attachments?: File[];
 	} & { signer: Signer }): Promise<{ digest: string; messageId: string }> {
+		const logger = getLogger(CATEGORIES.CLIENT_WRITES);
+		const senderAddress = signer.toSuiAddress();
+		logger.debug('Sending message', {
+			channelId,
+			memberCapId,
+			senderAddress,
+			messageLength: message.length,
+			attachmentCount: attachments?.length ?? 0,
+		});
+
 		const tx = new Transaction();
 		const sendMessageTxBuilder = await this.sendMessage(
 			channelId,
 			memberCapId,
-			signer.toSuiAddress(),
+			senderAddress,
 			message,
 			encryptedKey,
 			attachments,
@@ -980,6 +1023,14 @@ export class SuiStackMessagingClient {
 		if (messageId === undefined) {
 			throw new MessagingClientError('Message id not found on the transaction effects');
 		}
+
+		logger.info('Message sent', {
+			channelId,
+			messageId,
+			senderAddress,
+			hasAttachments: (attachments?.length ?? 0) > 0,
+			digest,
+		});
 
 		return { digest, messageId };
 	}
@@ -1087,6 +1138,12 @@ export class SuiStackMessagingClient {
 		digest: string;
 		addedMembers: AddedMemberCap[];
 	}> {
+		const logger = getLogger(CATEGORIES.CLIENT_WRITES);
+		logger.debug('Adding members to channel', {
+			channelId: options.channelId,
+			newMemberAddresses: options.newMemberAddresses,
+		});
+
 		const tx = transaction ?? new Transaction();
 		const addMembersTxBuilder = this.addMembers(options);
 		await addMembersTxBuilder(tx);
@@ -1118,6 +1175,13 @@ export class SuiStackMessagingClient {
 				memberCap: object,
 				ownerAddress,
 			};
+		});
+
+		logger.info('Members added to channel', {
+			channelId: options.channelId,
+			addedMemberCount: addedMembers.length,
+			memberCapIds: addedMembers.map((m) => m.memberCap.id.id),
+			digest,
 		});
 
 		return { digest, addedMembers };
@@ -1155,8 +1219,15 @@ export class SuiStackMessagingClient {
 		creatorCapId: string;
 		encryptedKeyBytes: Uint8Array<ArrayBuffer>;
 	}> {
+		const logger = getLogger(CATEGORIES.CLIENT_WRITES);
+		const creatorAddress = signer.toSuiAddress();
+		logger.debug('Creating channel', {
+			creatorAddress,
+			initialMemberCount: initialMembers?.length ?? 0,
+		});
+
 		const flow = this.createChannelFlow({
-			creatorAddress: signer.toSuiAddress(),
+			creatorAddress,
 			initialMemberAddresses: initialMembers,
 		});
 
@@ -1187,6 +1258,14 @@ export class SuiStackMessagingClient {
 
 		// Step 4: Get the encrypted key bytes
 		const { channelId, encryptedKeyBytes } = flow.getGeneratedEncryptionKey();
+
+		logger.info('Channel created', {
+			channelId,
+			creatorCapId: creatorCap.id.id,
+			creatorAddress,
+			memberCount: (initialMembers?.length ?? 0) + 1, // Including creator
+			digest: keyDigest,
+		});
 
 		return { digest: keyDigest, creatorCapId: creatorCap.id.id, channelId, encryptedKeyBytes };
 	}

--- a/packages/messaging/src/client.ts
+++ b/packages/messaging/src/client.ts
@@ -393,7 +393,10 @@ export class SuiStackMessagingClient {
 		const logger = getLogger(CATEGORIES.CLIENT_READS);
 		const { channelIds, userAddress, memberCapIds } = request;
 
-		logger.debug('Fetching channel objects by IDs', { channelCount: channelIds.length, userAddress });
+		logger.debug('Fetching channel objects by IDs', {
+			channelCount: channelIds.length,
+			userAddress,
+		});
 
 		const channelObjectsRes = await this.#suiClient.core.getObjects({
 			objectIds: channelIds,
@@ -706,6 +709,7 @@ export class SuiStackMessagingClient {
 		initialMemberAddresses,
 	}: CreateChannelFlowOpts): CreateChannelFlow {
 		const build = () => {
+			const logger = getLogger(CATEGORIES.CLIENT_WRITES);
 			const tx = new Transaction();
 			const config = tx.add(noneConfig());
 			const [channel, creatorCap, creatorMemberCap] = tx.add(newChannel({ arguments: { config } }));
@@ -717,8 +721,13 @@ export class SuiStackMessagingClient {
 					? this.#deduplicateAddresses(initialMemberAddresses, creatorAddress)
 					: [];
 			if (initialMemberAddresses && uniqueAddresses.length !== initialMemberAddresses.length) {
-				console.warn(
+				logger.warn(
 					'Duplicate addresses or creator address detected in initialMemberAddresses. Creator automatically receives a MemberCap. Using unique non-creator addresses only.',
+					{
+						originalCount: initialMemberAddresses?.length,
+						uniqueCount: uniqueAddresses.length,
+						creatorAddress,
+					},
 				);
 			}
 
@@ -1050,17 +1059,24 @@ export class SuiStackMessagingClient {
 	 */
 	addMembers({ channelId, memberCapId, newMemberAddresses, creatorCapId }: AddMembersOptions) {
 		return async (tx: Transaction) => {
+			const logger = getLogger(CATEGORIES.CLIENT_WRITES);
+
 			// Deduplicate addresses
 			const uniqueAddresses = this.#deduplicateAddresses(newMemberAddresses);
 
 			if (uniqueAddresses.length !== newMemberAddresses.length) {
-				console.warn(
+				logger.warn(
 					'Duplicate addresses detected in newMemberAddresses. Using unique addresses only.',
+					{
+						channelId,
+						originalCount: newMemberAddresses.length,
+						uniqueCount: uniqueAddresses.length,
+					},
 				);
 			}
 
 			if (uniqueAddresses.length === 0) {
-				console.warn('No members to add after deduplication.');
+				logger.warn('No members to add after deduplication.', { channelId });
 				return;
 			}
 

--- a/packages/messaging/src/encryption/envelopeEncryption.ts
+++ b/packages/messaging/src/encryption/envelopeEncryption.ts
@@ -5,6 +5,7 @@ import type { SessionKey } from '@mysten/seal';
 import { EncryptedObject } from '@mysten/seal';
 import { fromHex, isValidSuiObjectId, toHex } from '@mysten/sui/utils';
 
+import { getLogger, CATEGORIES } from '../logging/index.js';
 import type {
 	AttachmentMetadata,
 	DecryptAttachmentDataOpts,
@@ -84,6 +85,9 @@ export class EnvelopeEncryption {
 	async generateEncryptedChannelDEK({
 		channelId,
 	}: GenerateEncryptedChannelDEKopts): Promise<Uint8Array<ArrayBuffer>> {
+		const logger = getLogger(CATEGORIES.ENCRYPTION);
+		logger.debug('Generating encrypted channel DEK', { channelId });
+
 		if (!isValidSuiObjectId(channelId)) {
 			throw new Error('The channelId provided is not a valid Sui Object ID');
 		}
@@ -99,6 +103,12 @@ export class EnvelopeEncryption {
 			id,
 			data: dek,
 		});
+
+		logger.debug('Channel DEK generated and encrypted', {
+			channelId,
+			encryptedKeyLength: encryptedDekBytes.length,
+		});
+
 		return new Uint8Array(encryptedDekBytes);
 	}
 
@@ -126,6 +136,13 @@ export class EnvelopeEncryption {
 		encryptedKey,
 		memberCapId,
 	}: EncryptTextOpts): Promise<EncryptedPayload> {
+		const logger = getLogger(CATEGORIES.ENCRYPTION);
+		logger.debug('Encrypting text message', {
+			channelId,
+			textLength: text.length,
+			sender,
+		});
+
 		const nonce = this.#encryptionPrimitives.generateNonce();
 		const dek: SymmetricKey = await this.decryptChannelDEK({
 			encryptedKey,
@@ -163,6 +180,13 @@ export class EnvelopeEncryption {
 		sender,
 		memberCapId,
 	}: DecryptTextOpts): Promise<string> {
+		const logger = getLogger(CATEGORIES.ENCRYPTION);
+		logger.debug('Decrypting text message', {
+			channelId,
+			ciphertextLength: ciphertext.length,
+			sender,
+		});
+
 		const dek: SymmetricKey = await this.decryptChannelDEK({
 			encryptedKey,
 			channelId,

--- a/packages/messaging/src/encryption/envelopeEncryption.ts
+++ b/packages/messaging/src/encryption/envelopeEncryption.ts
@@ -5,7 +5,7 @@ import type { SessionKey } from '@mysten/seal';
 import { EncryptedObject } from '@mysten/seal';
 import { fromHex, isValidSuiObjectId, toHex } from '@mysten/sui/utils';
 
-import { getLogger, CATEGORIES } from '../logging/index.js';
+import { getLogger, LOG_CATEGORIES } from '../logging/index.js';
 import type {
 	AttachmentMetadata,
 	DecryptAttachmentDataOpts,
@@ -85,7 +85,7 @@ export class EnvelopeEncryption {
 	async generateEncryptedChannelDEK({
 		channelId,
 	}: GenerateEncryptedChannelDEKopts): Promise<Uint8Array<ArrayBuffer>> {
-		const logger = getLogger(CATEGORIES.ENCRYPTION);
+		const logger = getLogger(LOG_CATEGORIES.ENCRYPTION);
 		logger.debug('Generating encrypted channel DEK', { channelId });
 
 		if (!isValidSuiObjectId(channelId)) {
@@ -136,7 +136,7 @@ export class EnvelopeEncryption {
 		encryptedKey,
 		memberCapId,
 	}: EncryptTextOpts): Promise<EncryptedPayload> {
-		const logger = getLogger(CATEGORIES.ENCRYPTION);
+		const logger = getLogger(LOG_CATEGORIES.ENCRYPTION);
 		logger.debug('Encrypting text message', {
 			channelId,
 			textLength: text.length,
@@ -180,7 +180,7 @@ export class EnvelopeEncryption {
 		sender,
 		memberCapId,
 	}: DecryptTextOpts): Promise<string> {
-		const logger = getLogger(CATEGORIES.ENCRYPTION);
+		const logger = getLogger(LOG_CATEGORIES.ENCRYPTION);
 		logger.debug('Decrypting text message', {
 			channelId,
 			ciphertextLength: ciphertext.length,
@@ -562,7 +562,7 @@ export class EnvelopeEncryption {
 		channelId,
 		memberCapId,
 	}: DecryptChannelDEKOpts): Promise<SymmetricKey> {
-		const logger = getLogger(CATEGORIES.ENCRYPTION);
+		const logger = getLogger(LOG_CATEGORIES.ENCRYPTION);
 
 		if (!isValidSuiObjectId(channelId)) {
 			throw new Error('The channelId provided is not a valid Sui Object ID');

--- a/packages/messaging/src/encryption/envelopeEncryption.ts
+++ b/packages/messaging/src/encryption/envelopeEncryption.ts
@@ -562,6 +562,8 @@ export class EnvelopeEncryption {
 		channelId,
 		memberCapId,
 	}: DecryptChannelDEKOpts): Promise<SymmetricKey> {
+		const logger = getLogger(CATEGORIES.ENCRYPTION);
+
 		if (!isValidSuiObjectId(channelId)) {
 			throw new Error('The channelId provided is not a valid Sui Object ID');
 		}
@@ -601,7 +603,7 @@ export class EnvelopeEncryption {
 				checkLEEncoding: true, // Support legacy LE-encoded ciphertexts
 			});
 		} catch (error) {
-			console.error('Error decrypting channel DEK', error);
+			logger.error('Error decrypting channel DEK', { channelId, memberCapId, error });
 			throw error;
 		}
 		// const dekBytes = await this.#suiClient.seal.decrypt({

--- a/packages/messaging/src/index.ts
+++ b/packages/messaging/src/index.ts
@@ -32,3 +32,6 @@ export type { StorageAdapter, StorageConfig, StorageOptions } from './storage/ad
 // Walrus types
 export { WalrusStorageAdapter } from './storage/adapters/walrus/walrus.js';
 export type * from './storage/adapters/walrus/types.js';
+
+// Logging utilities (optional - requires @logtape/logtape peer dependency)
+export { getLogger, CATEGORIES } from './logging/index.js';

--- a/packages/messaging/src/index.ts
+++ b/packages/messaging/src/index.ts
@@ -34,4 +34,4 @@ export { WalrusStorageAdapter } from './storage/adapters/walrus/walrus.js';
 export type * from './storage/adapters/walrus/types.js';
 
 // Logging utilities (optional - requires @logtape/logtape peer dependency)
-export { getLogger, CATEGORIES } from './logging/index.js';
+export { getLogger, LOG_CATEGORIES } from './logging/index.js';

--- a/packages/messaging/src/logging/categories.ts
+++ b/packages/messaging/src/logging/categories.ts
@@ -1,0 +1,47 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * LogTape logging category constants for the Messaging SDK.
+ *
+ * Categories follow a hierarchical structure:
+ * - Root: ["@mysten/messaging"]
+ * - Client operations are split into reads and writes
+ * - Module-specific categories for encryption and storage
+ *
+ * Users can configure logging at any level in the hierarchy.
+ *
+ * @see https://jsr.io/@logtape/logtape for LogTape documentation
+ */
+export const CATEGORIES = {
+	/**
+	 * Root category for all Messaging SDK logs.
+	 * Configure this to enable/disable all SDK logging.
+	 */
+	ROOT: ['@mysten/messaging'] as const,
+
+	/**
+	 * Client read operations: fetching channels, messages, members, etc.
+	 */
+	CLIENT_READS: ['@mysten/messaging', 'client', 'reads'] as const,
+
+	/**
+	 * Client write operations: creating channels, sending messages, adding members, etc.
+	 */
+	CLIENT_WRITES: ['@mysten/messaging', 'client', 'writes'] as const,
+
+	/**
+	 * Encryption operations: envelope encryption, key generation, decryption.
+	 */
+	ENCRYPTION: ['@mysten/messaging', 'encryption'] as const,
+
+	/**
+	 * All storage adapter operations.
+	 */
+	STORAGE: ['@mysten/messaging', 'storage'] as const,
+
+	/**
+	 * Walrus-specific storage operations.
+	 */
+	STORAGE_WALRUS: ['@mysten/messaging', 'storage', 'walrus'] as const,
+} as const;

--- a/packages/messaging/src/logging/categories.ts
+++ b/packages/messaging/src/logging/categories.ts
@@ -14,19 +14,19 @@
  * @example
  * ```typescript
  * import { configure, getConsoleSink } from "@logtape/logtape";
- * import { CATEGORIES } from "@mysten/messaging";
+ * import { LOG_CATEGORIES } from "@mysten/messaging";
  *
  * await configure({
  *   sinks: { console: getConsoleSink() },
  *   loggers: [
- *     { category: CATEGORIES.ROOT, level: "info", sinks: ["console"] },
+ *     { category: LOG_CATEGORIES.ROOT, level: "info", sinks: ["console"] },
  *   ],
  * });
  * ```
  *
- * @see https://jsr.io/@logtape/logtape for LogTape documentation
+ * @see https://www.npmjs.com/package/@logtape/logtape for LogTape documentation
  */
-export const CATEGORIES = {
+export const LOG_CATEGORIES = {
 	/**
 	 * Root category for all Messaging SDK logs.
 	 * Configure this to enable/disable all SDK logging.

--- a/packages/messaging/src/logging/categories.ts
+++ b/packages/messaging/src/logging/categories.ts
@@ -11,6 +11,19 @@
  *
  * Users can configure logging at any level in the hierarchy.
  *
+ * @example
+ * ```typescript
+ * import { configure, getConsoleSink } from "@logtape/logtape";
+ * import { CATEGORIES } from "@mysten/messaging";
+ *
+ * await configure({
+ *   sinks: { console: getConsoleSink() },
+ *   loggers: [
+ *     { category: CATEGORIES.ROOT, level: "info", sinks: ["console"] },
+ *   ],
+ * });
+ * ```
+ *
  * @see https://jsr.io/@logtape/logtape for LogTape documentation
  */
 export const CATEGORIES = {
@@ -18,30 +31,30 @@ export const CATEGORIES = {
 	 * Root category for all Messaging SDK logs.
 	 * Configure this to enable/disable all SDK logging.
 	 */
-	ROOT: ['@mysten/messaging'] as const,
+	ROOT: ['@mysten/messaging'],
 
 	/**
 	 * Client read operations: fetching channels, messages, members, etc.
 	 */
-	CLIENT_READS: ['@mysten/messaging', 'client', 'reads'] as const,
+	CLIENT_READS: ['@mysten/messaging', 'client', 'reads'],
 
 	/**
 	 * Client write operations: creating channels, sending messages, adding members, etc.
 	 */
-	CLIENT_WRITES: ['@mysten/messaging', 'client', 'writes'] as const,
+	CLIENT_WRITES: ['@mysten/messaging', 'client', 'writes'],
 
 	/**
 	 * Encryption operations: envelope encryption, key generation, decryption.
 	 */
-	ENCRYPTION: ['@mysten/messaging', 'encryption'] as const,
+	ENCRYPTION: ['@mysten/messaging', 'encryption'],
 
 	/**
 	 * All storage adapter operations.
 	 */
-	STORAGE: ['@mysten/messaging', 'storage'] as const,
+	STORAGE: ['@mysten/messaging', 'storage'],
 
 	/**
 	 * Walrus-specific storage operations.
 	 */
-	STORAGE_WALRUS: ['@mysten/messaging', 'storage', 'walrus'] as const,
-} as const;
+	STORAGE_WALRUS: ['@mysten/messaging', 'storage', 'walrus'],
+};

--- a/packages/messaging/src/logging/index.ts
+++ b/packages/messaging/src/logging/index.ts
@@ -1,0 +1,27 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import { getLogger as getLogTapeLogger } from '@logtape/logtape';
+
+/**
+ * Get a logger for the specified category.
+ *
+ * This is a thin wrapper around LogTape's getLogger function.
+ * Use the CATEGORIES constants for consistency.
+ *
+ * @param category - The logging category (use CATEGORIES constants)
+ * @returns A logger instance
+ *
+ * @example
+ * ```typescript
+ * import { getLogger, CATEGORIES } from './logging/index.js';
+ *
+ * const logger = getLogger(CATEGORIES.CLIENT_READS);
+ * logger.info("Fetching channels", { count: 10 });
+ * ```
+ */
+export function getLogger(category: readonly string[]) {
+	return getLogTapeLogger(category);
+}
+
+export { CATEGORIES } from './categories.js';

--- a/packages/messaging/src/logging/index.ts
+++ b/packages/messaging/src/logging/index.ts
@@ -14,9 +14,9 @@ import { getLogger as getLogTapeLogger } from '@logtape/logtape';
  *
  * @example
  * ```typescript
- * import { getLogger, CATEGORIES } from './logging/index.js';
+ * import { getLogger, LOG_CATEGORIES } from './logging/index.js';
  *
- * const logger = getLogger(CATEGORIES.CLIENT_READS);
+ * const logger = getLogger(LOG_CATEGORIES.CLIENT_READS);
  * logger.info("Fetching channels", { count: 10 });
  * ```
  */
@@ -24,4 +24,4 @@ export function getLogger(category: readonly string[]) {
 	return getLogTapeLogger(category);
 }
 
-export { CATEGORIES } from './categories.js';
+export { LOG_CATEGORIES } from './categories.js';

--- a/packages/messaging/src/storage/adapters/walrus/walrus.ts
+++ b/packages/messaging/src/storage/adapters/walrus/walrus.ts
@@ -5,6 +5,8 @@ import type { StorageAdapter, StorageConfig, StorageOptions } from '../storage.j
 import type { WalrusClient } from '@mysten/walrus';
 import type { WalrusResponse } from './types.js';
 
+import { getLogger, CATEGORIES } from '../../../logging/index.js';
+
 export class WalrusStorageAdapter implements StorageAdapter {
 	constructor(
 		// Client parameter kept for future implementation - currently unused
@@ -20,7 +22,25 @@ export class WalrusStorageAdapter implements StorageAdapter {
 	 * @returns Upload result with blob IDs
 	 */
 	async upload(data: Uint8Array[], _options: StorageOptions): Promise<{ ids: string[] }> {
-		return await this.#uploadQuilts(data); // todo: option handling for blobs vs quilts
+		const logger = getLogger(CATEGORIES.STORAGE_WALRUS);
+		const totalBytes = data.reduce((sum, d) => sum + d.length, 0);
+
+		logger.debug('Uploading to Walrus', {
+			count: data.length,
+			totalBytes,
+			publisherUrl: this.config.publisher,
+			epochs: this.config.epochs,
+		});
+
+		const result = await this.#uploadQuilts(data); // todo: option handling for blobs vs quilts
+
+		logger.info('Uploaded to Walrus', {
+			count: result.ids.length,
+			blobIds: result.ids,
+			totalBytes,
+		});
+
+		return result;
 	}
 
 	/**
@@ -29,10 +49,25 @@ export class WalrusStorageAdapter implements StorageAdapter {
 	 * @returns Array of downloaded data
 	 */
 	async download(ids: string[]): Promise<Uint8Array[]> {
+		const logger = getLogger(CATEGORIES.STORAGE_WALRUS);
+		logger.debug('Downloading from Walrus', {
+			count: ids.length,
+			ids,
+			aggregatorUrl: this.config.aggregator,
+		});
+
 		if (ids.length === 0) {
 			return [];
 		}
-		return await this.#downloadQuilts(ids);
+
+		const result = await this.#downloadQuilts(ids);
+
+		logger.info('Downloaded from Walrus', {
+			count: result.length,
+			totalBytes: result.reduce((sum, d) => sum + d.length, 0),
+		});
+
+		return result;
 	}
 
 	/**
@@ -59,7 +94,13 @@ export class WalrusStorageAdapter implements StorageAdapter {
 		if (!response.ok) {
 			// Read the error response body to get the actual error message
 			const errorText = await response.text();
-			console.error('Error response body:', errorText);
+			const logger = getLogger(CATEGORIES.STORAGE_WALRUS);
+			logger.error('Walrus upload failed', {
+				status: response.status,
+				statusText: response.statusText,
+				errorText,
+				publisherUrl: this.config.publisher,
+			});
 			throw new Error(
 				`Walrus upload failed: ${response.status} ${response.statusText} - ${errorText}`,
 			);

--- a/packages/messaging/src/storage/adapters/walrus/walrus.ts
+++ b/packages/messaging/src/storage/adapters/walrus/walrus.ts
@@ -107,10 +107,7 @@ export class WalrusStorageAdapter implements StorageAdapter {
 		}
 
 		const result = await response.json();
-		// const blobId = this.#extractBlobId(result as WalrusResponse);
 		// TODO: figure out the Types, so we avoid the use of any
-		//  // @ts-ignore
-		// console.log((await this.client.walrus.getBlob({blobId})));
 		return { ids: this.#extractQuiltsPatchIds(result as WalrusResponse) };
 	}
 

--- a/packages/messaging/src/storage/adapters/walrus/walrus.ts
+++ b/packages/messaging/src/storage/adapters/walrus/walrus.ts
@@ -5,7 +5,7 @@ import type { StorageAdapter, StorageConfig, StorageOptions } from '../storage.j
 import type { WalrusClient } from '@mysten/walrus';
 import type { WalrusResponse } from './types.js';
 
-import { getLogger, CATEGORIES } from '../../../logging/index.js';
+import { getLogger, LOG_CATEGORIES } from '../../../logging/index.js';
 
 export class WalrusStorageAdapter implements StorageAdapter {
 	constructor(
@@ -22,7 +22,7 @@ export class WalrusStorageAdapter implements StorageAdapter {
 	 * @returns Upload result with blob IDs
 	 */
 	async upload(data: Uint8Array[], _options: StorageOptions): Promise<{ ids: string[] }> {
-		const logger = getLogger(CATEGORIES.STORAGE_WALRUS);
+		const logger = getLogger(LOG_CATEGORIES.STORAGE_WALRUS);
 		const totalBytes = data.reduce((sum, d) => sum + d.length, 0);
 
 		logger.debug('Uploading to Walrus', {
@@ -49,7 +49,7 @@ export class WalrusStorageAdapter implements StorageAdapter {
 	 * @returns Array of downloaded data
 	 */
 	async download(ids: string[]): Promise<Uint8Array[]> {
-		const logger = getLogger(CATEGORIES.STORAGE_WALRUS);
+		const logger = getLogger(LOG_CATEGORIES.STORAGE_WALRUS);
 		logger.debug('Downloading from Walrus', {
 			count: ids.length,
 			ids,
@@ -94,7 +94,7 @@ export class WalrusStorageAdapter implements StorageAdapter {
 		if (!response.ok) {
 			// Read the error response body to get the actual error message
 			const errorText = await response.text();
-			const logger = getLogger(CATEGORIES.STORAGE_WALRUS);
+			const logger = getLogger(LOG_CATEGORIES.STORAGE_WALRUS);
 			logger.error('Walrus upload failed', {
 				status: response.status,
 				statusText: response.statusText,


### PR DESCRIPTION
Integrate the [LogTape](https://logtape.org/) library in the ts-sdk.

- Refactor any console logging with the LogTape logger.
- Update the docs with usage guidelines for logging.