### PR TITLE
feat(ts-sdk): add standalone messaging() function for client extension

### DIFF
--- a/Setup.md
+++ b/Setup.md
@@ -28,7 +28,7 @@ Before extending your client, ensure you have:
 ```typescript
 import { SuiClient } from "@mysten/sui/client";
 import { SealClient } from "@mysten/seal";
-import { SuiStackMessagingClient } from "@mysten/sui-messaging";
+import { messaging } from "@mysten/messaging";
 ```
 
 ### Step-by-Step extension
@@ -74,11 +74,11 @@ const clientWithSeal = baseClient.$extend(
 
 Refer to [verified key servers](https://seal-docs.wal.app/Pricing/#verified-key-servers) for the list of verified key servers on Testnet and Mainnet.
 
-**Step 3: Extend with SuiStackMessagingClient**
+**Step 3: Extend with messaging**
 
 ```typescript
 const messagingClient = clientWithSeal.$extend(
-  SuiStackMessagingClient.experimental_asClientExtension({
+  messaging({
     // Session key configuration (choose one of the available approaches - see below)
     sessionKeyConfig: {
       address: "0x...", // User's Sui address
@@ -104,7 +104,7 @@ const messagingClient = clientWithSeal.$extend(
 );
 
 // Access messaging functionality
-const messaging = messagingClient.messaging;
+const msg = messagingClient.messaging;
 ```
 
 ### Complete extension example
@@ -137,7 +137,7 @@ const client = new SuiClient({
     })
   )
   .$extend(
-    SuiStackMessagingClient.experimental_asClientExtension({
+    messaging({
       sessionKeyConfig: {
         address: "0x...",
         ttlMin: 30,
@@ -188,7 +188,7 @@ import { SessionKey } from "@mysten/seal";
 
 const mySessionKey = await SessionKey.create(/* ... */);
 
-SuiStackMessagingClient.experimental_asClientExtension({
+messaging({
   sessionKey: mySessionKey,
   // ... other config
 });
@@ -268,7 +268,7 @@ class MyCustomStorage implements StorageAdapter {
   }
 }
 
-SuiStackMessagingClient.experimental_asClientExtension({
+messaging({
   storage: (client) => new MyCustomStorage(client),
   // ... other config
 });
@@ -304,7 +304,7 @@ SealClient.asClientExtension({
 });
 
 // MessagingClient: Configure threshold (how many servers must participate)
-SuiStackMessagingClient.experimental_asClientExtension({
+messaging({
   sealConfig: {
     threshold: 2, // Require 2 out of 3 key servers
   },
@@ -332,7 +332,7 @@ packageConfig: {
 **Example:**
 
 ```typescript
-SuiStackMessagingClient.experimental_asClientExtension({
+messaging({
   packageConfig: {
     packageId: "0xabc123...",
     sealApproveContract: {

--- a/packages/.changeset/common-apples-swim.md
+++ b/packages/.changeset/common-apples-swim.md
@@ -1,0 +1,6 @@
+---
+'@mysten/messaging': minor
+---
+
+Add standalone `messaging()` function as the recommended way to create client extensions.
+The `SuiStackMessagingClient.experimental_asClientExtension()` static method is now soft-deprecated.

--- a/packages/messaging/src/client.ts
+++ b/packages/messaging/src/client.ts
@@ -80,7 +80,7 @@ export class SuiStackMessagingClient {
 	// #encryptedChannelDEKCache: Map<string, EncryptedSymmetricKey> = new Map(); // channelId --> EncryptedSymmetricKey
 	// #channelMessagesTableIdCache: Map<string, string> = new Map<string, string>(); // channelId --> messagesTableId
 
-	private constructor(public options: MessagingClientOptions) {
+	constructor(public options: MessagingClientOptions) {
 		this.#suiClient = options.suiClient;
 		this.#storage = options.storage;
 
@@ -124,7 +124,7 @@ export class SuiStackMessagingClient {
 		});
 	}
 
-	// TODO: Move to standalone function (pattern used in other Mysten TypeScript SDKs)
+	/** @deprecated use `messaging()` instead */
 	static experimental_asClientExtension(options: MessagingClientExtensionOptions) {
 		return {
 			name: 'messaging' as const,
@@ -1584,4 +1584,77 @@ export class SuiStackMessagingClient {
 		// Filter out null values and return
 		return contents.filter((content): content is Uint8Array => content !== null);
 	}
+}
+
+/**
+ * Creates a client extension for Sui Stack Messaging.
+ *
+ * @example
+ * ```typescript
+ * const client = new SuiClient({ url: '...' })
+ *   .$extend(SealClient.asClientExtension({ serverConfigs: [...] }))
+ *   .$extend(messaging({
+ *     walrusStorageConfig: { publisher: '...', aggregator: '...', epochs: 1 },
+ *     sessionKeyConfig: { address: '...', ttlMin: 30 },
+ *   }));
+ *
+ * // Access messaging functionality
+ * const { channelId } = await client.messaging.executeCreateChannelTransaction({ signer });
+ * ```
+ */
+export function messaging(options: MessagingClientExtensionOptions) {
+	return {
+		name: 'messaging' as const,
+		register: (client: MessagingCompatibleClient) => {
+			const sealClient = client.seal;
+
+			if (!sealClient) {
+				throw new MessagingClientError('SealClient extension is required for MessagingClient');
+			}
+
+			// Check if storage configuration is provided
+			if (!('storage' in options) && !('walrusStorageConfig' in options)) {
+				throw new MessagingClientError(
+					'Either a custom storage adapter via "storage" option or explicit Walrus storage configuration via "walrusStorageConfig" option must be provided. Fallback to default Walrus endpoints is not supported.',
+				);
+			}
+
+			// Auto-detect network from the client or use default package config
+			let packageConfig = options.packageConfig;
+			if (!packageConfig) {
+				const network = client.network;
+				switch (network) {
+					case 'testnet':
+						packageConfig = TESTNET_MESSAGING_PACKAGE_CONFIG;
+						break;
+					case 'mainnet':
+						packageConfig = MAINNET_MESSAGING_PACKAGE_CONFIG;
+						break;
+					default:
+						// Fallback to testnet if network is not recognized
+						packageConfig = TESTNET_MESSAGING_PACKAGE_CONFIG;
+						break;
+				}
+			}
+
+			// Handle storage configuration
+			const storage =
+				'storage' in options
+					? (c: MessagingCompatibleClient) => options.storage(c)
+					: (c: MessagingCompatibleClient) => {
+							// WalrusClient is optional - we can use WalrusStorageAdapter without it
+							// In the future, when WalrusClient SDK is used, we can check for its presence and use different logic
+							return new WalrusStorageAdapter(c, options.walrusStorageConfig);
+						};
+
+			return new SuiStackMessagingClient({
+				suiClient: client,
+				storage,
+				packageConfig,
+				sessionKey: 'sessionKey' in options ? options.sessionKey : undefined,
+				sessionKeyConfig: 'sessionKeyConfig' in options ? options.sessionKeyConfig : undefined,
+				sealConfig: options.sealConfig,
+			});
+		},
+	};
 }

--- a/packages/messaging/src/index.ts
+++ b/packages/messaging/src/index.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 // Main client class
-export { SuiStackMessagingClient } from './client.js';
+export { SuiStackMessagingClient, messaging } from './client.js';
 
 // Types
 export type * from './types.js';

--- a/packages/messaging/test/test-helpers.ts
+++ b/packages/messaging/test/test-helpers.ts
@@ -11,7 +11,7 @@ import { Transaction } from '@mysten/sui/transactions';
 import { GenericContainer, Network } from 'testcontainers';
 import path from 'path';
 
-import { SuiStackMessagingClient } from '../src/client';
+import { messaging } from '../src/client';
 import { WalrusStorageAdapter } from '../src/storage/adapters/walrus/walrus';
 
 import * as channelModule from '../src/contracts/sui_stack_messaging/channel';
@@ -430,7 +430,7 @@ export function createTestClient(
 
 	return config.environment === 'localnet'
 		? suiRpcClient.$extend(MockSealClient.asClientExtension()).$extend(
-				SuiStackMessagingClient.experimental_asClientExtension({
+				messaging({
 					packageConfig: config.packageConfig,
 					storage: (_client) => mockStorage,
 					sessionKeyConfig: {
@@ -450,7 +450,7 @@ export function createTestClient(
 					}),
 				)
 				.$extend(
-					SuiStackMessagingClient.experimental_asClientExtension({
+					messaging({
 						packageConfig: config.packageConfig,
 						storage: (client) => {
 							if (!config.walrusConfig) {


### PR DESCRIPTION

### Following the latest recommendation for mysten's ts-sdks:

- Add `messaging()` standalone function as the recommended way to create client extensions.
- `SuiStackMessagingClient.experimental_asClientExtension()` is now soft-deprecated.