### PR TITLE
feat(ts-sdk): add getUserMemberCap and getCreatorCap methods with auto-fetch for addMembers

### DIFF
--- a/packages/.changeset/young-foxes-send.md
+++ b/packages/.changeset/young-foxes-send.md
@@ -1,0 +1,10 @@
+---
+'@mysten/messaging': minor
+---
+
+Add `getUserMemberCap()` and `getCreatorCap()` methods for fetching user capabilities by channel
+
+- `getUserMemberCap(userAddress, channelId)`: Returns user's MemberCap for a specific channel
+- `getCreatorCap(userAddress, channelId)`: Returns user's CreatorCap for a specific channel
+- `addMembers` methods now auto-fetch CreatorCap when `address` is provided instead of `creatorCapId`
+- Both methods handle pagination internally, simplifying common lookup patterns

--- a/packages/messaging/src/types.ts
+++ b/packages/messaging/src/types.ts
@@ -88,21 +88,45 @@ export interface CreateChannelFlow {
 	};
 }
 
-// Add Members interfaces
-export interface AddMembersOptions {
+// Add Members interfaces - base options shared by all variants
+interface AddMembersBaseOptions {
 	channelId: string;
 	memberCapId: string;
 	newMemberAddresses: string[];
+}
+
+// Variant 1: User provides the creatorCapId directly
+export interface AddMembersWithCreatorCapId extends AddMembersBaseOptions {
 	creatorCapId: string;
+	address?: never;
 }
 
-export interface AddMembersTransactionOptions extends AddMembersOptions {
+// Variant 2: User provides their address to auto-fetch the CreatorCap
+export interface AddMembersWithAddress extends AddMembersBaseOptions {
+	creatorCapId?: never;
+	/**
+	 * The address to use for fetching the CreatorCap.
+	 * Required when creatorCapId is not provided.
+	 */
+	address: string;
+}
+
+/**
+ * Options for adding members to a channel.
+ * Either provide `creatorCapId` directly, or provide `address` to auto-fetch the CreatorCap.
+ */
+export type AddMembersOptions = AddMembersWithCreatorCapId | AddMembersWithAddress;
+
+export interface AddMembersTransactionOptions extends AddMembersBaseOptions {
 	transaction?: Transaction;
+	creatorCapId?: string;
+	address?: string;
 }
 
-export interface ExecuteAddMembersTransactionOptions extends AddMembersOptions {
+export interface ExecuteAddMembersTransactionOptions extends AddMembersBaseOptions {
 	transaction?: Transaction;
 	signer: Signer;
+	creatorCapId?: string;
 }
 
 export interface AddedMemberCap {


### PR DESCRIPTION
## Summary
- Add `getUserMemberCap(userAddress, channelId)` method for fetching a user's MemberCap for a specific channel
- Add `getCreatorCap(userAddress, channelId)` method for fetching a user's CreatorCap for a specific channel
- `addMembers` methods now auto-fetch CreatorCap when `address` is provided instead of `creatorCapId`
- Both methods handle pagination internally, simplifying common lookup patterns

## Test plan
- [x] Updated integration tests to use new methods
- [x] Type checks pass
- [x] Documentation updated (APIRef.md, Examples.md)