### PR TITLE
fix: harden 0.4.0 migration for latest Sui/Seal and CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,51 @@
+name: CI
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+jobs:
+  build-and-test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          package_json_file: packages/package.json
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          cache: "pnpm"
+          cache-dependency-path: "packages/pnpm-lock.yaml"
+
+      - name: Install dependencies
+        run: |
+          cd packages
+          pnpm install
+
+      - name: Build
+        run: |
+          cd packages/messaging
+          pnpm build
+
+      - name: Lint
+        run: |
+          cd packages/messaging
+          pnpm lint
+
+      - name: Unit tests
+        run: |
+          cd packages/messaging
+          pnpm run test:unit
+
+      - name: Integration tests (localnet)
+        run: |
+          cd packages/messaging
+          TEST_ENVIRONMENT=localnet pnpm run test:integration

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -41,7 +41,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: "20"
+          node-version: "22"
           registry-url: "https://registry.npmjs.org"
           cache: "pnpm"
           cache-dependency-path: "packages/pnpm-lock.yaml"
@@ -92,7 +92,7 @@ jobs:
       - name: Setup Node.js with npm registry
         uses: actions/setup-node@v4
         with:
-          node-version: "20"
+          node-version: "22"
           registry-url: "https://registry.npmjs.org"
           cache: "pnpm"
           cache-dependency-path: "packages/pnpm-lock.yaml"
@@ -111,6 +111,11 @@ jobs:
         run: |
           cd packages/messaging
           pnpm lint
+
+      - name: Run unit tests
+        run: |
+          cd packages/messaging
+          pnpm run test:unit
 
       - name: Ensure npm version 11.5.1+
         run: |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,45 @@
+# Mainnet Deployment Note (2026-02-16)
+
+Executed on mainnet successfully with address `0x3db42086e9271787046859d60af7933fa7ea70148df37c9fd693195533eabb57`.
+
+- Active address: `0x3db42086e9271787046859d60af7933fa7ea70148df37c9fd693195533eabb57`
+- Tx digest: `E551CSSGWQsXChSCFQPR7BNMWWQv7TB7KYV2iyZkxVyz`
+- Status: `Success`
+- New upgraded package ID: `0x74e34e2e4a2ba60d935db245c0ed93070bbbe23bf1558ae5c6a2a8590c8ad470`
+- Upgrade cap (same object, new version): `0x1829ea7b90624dc019fd4df90e58bc092da03117f11ff585af958f0fb074d324`
+- SUI spent: `78,506,620` mist (`0.07850662 SUI`)
+
+Local metadata was updated at:
+
+- `move/sui_stack_messaging/Published.toml:7`
+- `move/sui_stack_messaging/Published.toml:9`
+
+To use this package in apps, pass the package ID explicitly:
+
+```ts
+const client = new SuiStackMessagingClient({
+  suiClient,
+  storage,
+  packageConfig: {
+    packageId: "0x74e34e2e4a2ba60d935db245c0ed93070bbbe23bf1558ae5c6a2a8590c8ad470",
+  },
+  // sessionKey/sessionKeyConfig + seal config...
+});
+```
+
+Note: repo default constants still point to an older fallback ID in `packages/messaging/src/constants.ts:6`.
+
+## DevOps
+
+CDN manifest for this deployment is committed at `cdn/messaging-mainnet.json`.
+
+- Git tag: `mainnet-messaging-v2-2026-02-16`
+- Manifest commit: `e7280c8`
+- jsDelivr URL: `https://cdn.jsdelivr.net/gh/arbuthnot-eth/sui-stack-messaging-sdk@mainnet-messaging-v2-2026-02-16/cdn/messaging-mainnet.json`
+- Raw GitHub URL: `https://raw.githubusercontent.com/arbuthnot-eth/sui-stack-messaging-sdk/mainnet-messaging-v2-2026-02-16/cdn/messaging-mainnet.json`
+
+Recommended consumption pattern:
+
+1. Fetch manifest from jsDelivr.
+2. Read `packageId`.
+3. Inject into SDK `packageConfig.packageId` at runtime.

--- a/cdn/messaging-mainnet.json
+++ b/cdn/messaging-mainnet.json
@@ -1,0 +1,11 @@
+{
+  "network": "mainnet",
+  "date": "2026-02-16",
+  "activeAddress": "0x3db42086e9271787046859d60af7933fa7ea70148df37c9fd693195533eabb57",
+  "status": "Success",
+  "txDigest": "E551CSSGWQsXChSCFQPR7BNMWWQv7TB7KYV2iyZkxVyz",
+  "packageId": "0x74e34e2e4a2ba60d935db245c0ed93070bbbe23bf1558ae5c6a2a8590c8ad470",
+  "upgradeCapId": "0x1829ea7b90624dc019fd4df90e58bc092da03117f11ff585af958f0fb074d324",
+  "suiSpentMist": "78506620",
+  "suiSpent": "0.07850662"
+}

--- a/packages/messaging/package.json
+++ b/packages/messaging/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@mysten/messaging",
-	"version": "0.3.0",
+	"version": "0.4.0",
 	"description": "Messaging SDK (Alpha - Experimental)",
 	"license": "Apache-2.0",
 	"author": "Mysten Labs <build@mystenlabs.com>",
@@ -53,10 +53,11 @@
 	"homepage": "https://github.com/MystenLabs/sui-stack-messaging-sdk#readme",
 	"dependencies": {
 		"@logtape/logtape": "^1.2.0",
-		"@mysten/bcs": "^1.9.2",
-		"@mysten/seal": "^0.9.6",
-		"@mysten/sui": "^1.45.2",
-		"@mysten/walrus": "^0.8.6"
+		"@mysten/bcs": "^2.0.2",
+		"@mysten/seal": "^1.0.1",
+		"@mysten/sui": "^2.4.0",
+		"@mysten/suins": "^1.0.2",
+		"@mysten/walrus": "^1.0.3"
 	},
 	"devDependencies": {
 		"@changesets/cli": "^2.29.6",
@@ -93,6 +94,7 @@
 		"vitest": "^3.2.4"
 	},
 	"engines": {
+		"node": ">=22",
 		"pnpm": ">=10.17.0"
 	},
 	"manypkg": {

--- a/scripts/utils.ts
+++ b/scripts/utils.ts
@@ -1,12 +1,7 @@
 /* --- Place your @mysten/sui imports here --- */
 import { execSync } from "child_process";
-import {
-  SuiClient,
-  SuiObjectChange,
-  SuiTransactionBlockResponse,
-} from "@mysten/sui/client";
+import type { ClientWithCoreApi } from "@mysten/sui/client";
 import { Transaction } from "@mysten/sui/transactions";
-
 import { Ed25519Keypair } from "@mysten/sui/keypairs/ed25519";
 import { decodeSuiPrivateKey } from "@mysten/sui/cryptography";
 
@@ -26,25 +21,34 @@ export const createKeypairFromPrivateKey = (
 };
 
 /**
- * @param {SuiClient} client - The SuiClient instance
+ * @param {ClientWithCoreApi} client - The Sui client instance
  * @param {Transaction} transaction - The Transaction instance
  * @param {Ed25519Keypair} signer - The Keypair signer
- * @return {Promise<SuiTransactionBlockResponse>}
+ * @return {Promise<{ digest: string }>}
  */
 export async function executeTransaction(
-  client: SuiClient,
+  client: ClientWithCoreApi,
   transaction: Transaction,
   signer: Ed25519Keypair
-): Promise<SuiTransactionBlockResponse> {
-  const txResult = await client.signAndExecuteTransaction({
+): Promise<{ digest: string }> {
+  const result = await client.core.signAndExecuteTransaction({
     transaction,
     signer,
-    options: {
-      showEffects: true,
-      showObjectChanges: true,
+    include: {
+      effects: true,
     },
   });
 
-  await client.waitForTransaction({ digest: txResult.digest });
-  return txResult;
+  if (result.$kind === "FailedTransaction") {
+    throw new Error(
+      `Transaction failed: ${JSON.stringify(
+        result.FailedTransaction.status.error
+      )}`
+    );
+  }
+
+  await client.core.waitForTransaction({
+    digest: result.Transaction.digest,
+  });
+  return { digest: result.Transaction.digest };
 }


### PR DESCRIPTION
## Summary
This PR hardens the `0.4.0` migration for latest Sui/Seal by addressing runtime and API-compatibility gaps discovered during validation.

Fixes #60

### Changes
- Update GitHub Actions workflows to Node 22 (required by `@mysten/sui@2.4.0`):
  - `.github/workflows/ci.yml`
  - `.github/workflows/npm-publish.yml`
- Add integration coverage to CI localnet flow:
  - run `TEST_ENVIRONMENT=localnet pnpm run test:integration`
- Add pre-publish unit-test gate in npm publish workflow.
- Align script helper with current Sui client typing/API:
  - `scripts/utils.ts`
  - use `ClientWithCoreApi` and `client.core.signAndExecuteTransaction(...)`
  - use `client.core.waitForTransaction(...)`
- Enforce engine floor in package metadata:
  - `packages/messaging/package.json` -> `"node": ">=22"`
- Record successful mainnet deployment + CDN manifest:
  - `AGENTS.md`
  - `cdn/messaging-mainnet.json`

## Validation
- `pnpm -C packages/messaging build`
- `pnpm -C packages/messaging lint`
- `pnpm -C packages/messaging test:unit`
- `pnpm -C scripts exec tsc -p tsconfig.json --noEmit`

Integration tests require Docker-capable runtime for testcontainers.
